### PR TITLE
Minor changes to Chapter.cs - details in description

### DIFF
--- a/MangaRipper.Core/Models/Chapter.cs
+++ b/MangaRipper.Core/Models/Chapter.cs
@@ -9,13 +9,13 @@ namespace MangaRipper.Core.Models
         public string OriginalName { get; }
         public int Prefix { get; set; }
 
-        public string Name => Prefix > 0 ? $"[{Prefix:000}] - {OriginalName.RemoveFileNameInvalidChar()}" : OriginalName.RemoveFileNameInvalidChar();
+        public string Name => Prefix > 0 ? $"[{Prefix:000}] {OriginalName.RemoveFileNameInvalidChar()}" : OriginalName.RemoveFileNameInvalidChar();
 
         public string Url { get;}
 
-        public Chapter(string name, string url)
+        public Chapter(string originalName, string url)
         {
-            OriginalName = name;
+            OriginalName = originalName;
             Url = url;
         }
 


### PR DESCRIPTION
Hi, I wanted to get some manga from Kissanime and change the format through Calibre to read on my Kindle. I encountered two annoyances:

1) The dashes in the file names act as some sort of delimiter in Calibre and screw up the metadata. For this I removed the dash between the prefix and the original name from the 'Name' member. I think that the prefix being enclosed in brackets is enough but the final decision is up to you since my case may be too obscure.

2) I found it strange that the prefix was being doubled when tranferring chapter to the right table for download. I found a potential problem in the constructor of the chapter.cs file. When doing a deep clone and passing down the deserialized objects the constructor accepts the name, which already contains the prefix, and assigns it to the original name. By doing this the next time you want to get the name you double the prefix string - hence the behaviour. To correct this i changed the constructor to take in the original name instead. I may have misunderstood the feature since I did not make a full analysis so excuse me if that is indeed the case.