### PR TITLE
KissManga chapter pattern fix

### DIFF
--- a/MangaRipper.Core/Controllers/WorkerController.cs
+++ b/MangaRipper.Core/Controllers/WorkerController.cs
@@ -105,7 +105,7 @@ namespace MangaRipper.Core.Controllers
             var chapter = task.Chapter;
             progress.Report(0);
             var service = FrameworkProvider.GetService(chapter.Url);
-            var images = await service.FindImanges(chapter, new Progress<int>(count =>
+            var images = await service.FindImages(chapter, new Progress<int>(count =>
             {
                 progress.Report(count / 2);
             }), _source.Token);

--- a/MangaRipper.Core/Interfaces/IMangaService.cs
+++ b/MangaRipper.Core/Interfaces/IMangaService.cs
@@ -20,7 +20,7 @@ namespace MangaRipper.Core.Interfaces
 
         /// <summary>
         /// Is a link is from this service.
-        /// If it's. We can use this service to fetch chapters and download
+        /// If it is. We can use this service to fetch chapters and download
         /// </summary>
         /// <param name="link"></param>
         /// <returns></returns>
@@ -42,6 +42,6 @@ namespace MangaRipper.Core.Interfaces
         /// <param name="progress"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<string>> FindImanges(Chapter chapter, IProgress<int> progress, CancellationToken cancellationToken);
+        Task<IEnumerable<string>> FindImages(Chapter chapter, IProgress<int> progress, CancellationToken cancellationToken);
     }
 }

--- a/MangaRipper.Core/Interfaces/MangaService.cs
+++ b/MangaRipper.Core/Interfaces/MangaService.cs
@@ -25,7 +25,7 @@ namespace MangaRipper.Core.Interfaces
         public abstract Task<IEnumerable<Chapter>> FindChapters(string manga, IProgress<int> progress,
             CancellationToken cancellationToken);
 
-        public abstract Task<IEnumerable<string>> FindImanges(Chapter chapter, IProgress<int> progress,
+        public abstract Task<IEnumerable<string>> FindImages(Chapter chapter, IProgress<int> progress,
             CancellationToken cancellationToken);
     }
 }

--- a/MangaRipper.Core/Services/DownloadService.cs
+++ b/MangaRipper.Core/Services/DownloadService.cs
@@ -22,7 +22,7 @@ namespace MangaRipper.Core.Services
         public CookieCollection Cookies { get; set; }
 
         public string Referrer { get; set; }
-
+        
         private HttpClient CreateRequest()
         {
             var firstHandle = new HttpClientHandler

--- a/MangaRipper.Plugin.Batoto/Batoto.cs
+++ b/MangaRipper.Plugin.Batoto/Batoto.cs
@@ -68,8 +68,8 @@ namespace MangaRipper.Plugin.Batoto
             progress.Report(100);
             return chaps;
         }
-
-        public override async Task<IEnumerable<string>> FindImanges(Chapter chapter, IProgress<int> progress, CancellationToken cancellationToken)
+        
+        public override async Task<IEnumerable<string>> FindImages(Chapter chapter, IProgress<int> progress, CancellationToken cancellationToken)
         {
             progress.Report(0);
             var downloader = new DownloadService

--- a/MangaRipper.Plugin.KissManga/KissManga.cs
+++ b/MangaRipper.Plugin.KissManga/KissManga.cs
@@ -32,7 +32,7 @@ namespace MangaRipper.Plugin.KissManga
             return chaps;
         }
 
-        public override async Task<IEnumerable<string>> FindImanges(Chapter chapter, IProgress<int> progress, CancellationToken cancellationToken)
+        public override async Task<IEnumerable<string>> FindImages(Chapter chapter, IProgress<int> progress, CancellationToken cancellationToken)
         {
             var downloader = new DownloadService();
             var parser = new ParserHelper();

--- a/MangaRipper.Plugin.KissManga/KissManga.cs
+++ b/MangaRipper.Plugin.KissManga/KissManga.cs
@@ -26,7 +26,7 @@ namespace MangaRipper.Plugin.KissManga
             progress.Report(0);
             // find all chapters in a manga
             string input = await downloader.DownloadStringAsync(manga);
-            var chaps = parser.ParseGroup("<td>\n<a href=\"(?=/Manga/)(?<Value>.[^\"]*)\" title=\"(?<Name>.[^\"]*)\"", input, "Name", "Value");
+            var chaps = parser.ParseGroup("<td>\\s+<a\\s+href=\"(?=/Manga/)(?<Value>.[^\"]*)\"\\s+title=\"(?<Name>.[^\"]*)\"", input, "Name", "Value");
             chaps = chaps.Select(c => NameResolver(c.Name, c.Url, new Uri(manga)));
             progress.Report(100);
             return chaps;

--- a/MangaRipper.Plugin.MangaFox/MangaFox.cs
+++ b/MangaRipper.Plugin.MangaFox/MangaFox.cs
@@ -34,6 +34,7 @@ namespace MangaRipper.Plugin.MangaFox
             Logger.Info($@"> FindChapters(): {manga}");
             progress.Report(0);
             var downloader = new DownloadService();
+
             var parser = new ParserHelper();
 
             // find all chapters in a manga
@@ -42,8 +43,8 @@ namespace MangaRipper.Plugin.MangaFox
             progress.Report(100);
             return chaps;
         }
-
-        public override async Task<IEnumerable<string>> FindImanges(Chapter chapter, IProgress<int> progress, CancellationToken cancellationToken)
+        
+        public override async Task<IEnumerable<string>> FindImages(Chapter chapter, IProgress<int> progress, CancellationToken cancellationToken)
         {
             progress.Report(0);
             var downloader = new DownloadService();

--- a/MangaRipper.Plugin.MangaHere/MangaHere.cs
+++ b/MangaRipper.Plugin.MangaHere/MangaHere.cs
@@ -30,8 +30,8 @@ namespace MangaRipper.Plugin.MangaHere
             progress.Report(100);
             return chaps;
         }
-
-        public override async Task<IEnumerable<string>> FindImanges(Chapter chapter, IProgress<int> progress, CancellationToken cancellationToken)
+        
+        public override async Task<IEnumerable<string>> FindImages(Chapter chapter, IProgress<int> progress, CancellationToken cancellationToken)
         {
             var downloader = new DownloadService();
             var parser = new ParserHelper();

--- a/MangaRipper.Plugin.MangaReader/MangaReader.cs
+++ b/MangaRipper.Plugin.MangaReader/MangaReader.cs
@@ -33,8 +33,8 @@ namespace MangaRipper.Plugin.MangaReader
             progress.Report(100);
             return chaps;
         }
-
-        public override async Task<IEnumerable<string>> FindImanges(Chapter chapter, IProgress<int> progress, CancellationToken cancellationToken)
+        
+        public override async Task<IEnumerable<string>> FindImages(Chapter chapter, IProgress<int> progress, CancellationToken cancellationToken)
         {
             var downloader = new DownloadService();
             var parser = new ParserHelper();

--- a/MangaRipper.Plugin.MangaShare/MangaShare.cs
+++ b/MangaRipper.Plugin.MangaShare/MangaShare.cs
@@ -31,8 +31,8 @@ namespace MangaRipper.Plugin.MangaShare
             progress.Report(100);
             return chaps;
         }
-
-        public override async Task<IEnumerable<string>> FindImanges(Chapter chapter, IProgress<int> progress, CancellationToken cancellationToken)
+        
+        public override async Task<IEnumerable<string>> FindImages(Chapter chapter, IProgress<int> progress, CancellationToken cancellationToken)
         {
             var downloader = new DownloadService();
             var parser = new ParserHelper();

--- a/MangaRipper.Plugin.MangaStream/MangaStream.cs
+++ b/MangaRipper.Plugin.MangaStream/MangaStream.cs
@@ -33,7 +33,7 @@ namespace MangaRipper.Plugin.MangaStream
             return chaps;
         }
 
-        public override async Task<IEnumerable<string>> FindImanges(Chapter chapter, IProgress<int> progress,
+        public override async Task<IEnumerable<string>> FindImages(Chapter chapter, IProgress<int> progress,
             CancellationToken cancellationToken)
         {
             var downloader = new DownloadService();

--- a/MangaRipper.Test/Plugin.cs
+++ b/MangaRipper.Test/Plugin.cs
@@ -43,7 +43,7 @@ namespace MangaRipper.Test
             var anyDuplicated = chapters.GroupBy(x => x.Url).Any(g => g.Count() > 1);
             Assert.IsFalse(anyDuplicated, "There're duplicated chapters.");
             // Test service can find images.
-            var images = await service.FindImanges(chapter, new Progress<int>(), _source.Token);
+            var images = await service.FindImages(chapter, new Progress<int>(), _source.Token);
             Assert.AreEqual(53, images.Count());
             Assert.AreEqual("http://i10.mangareader.net/naruto/1/naruto-1564773.jpg", images.ToArray()[0]);
             Assert.AreEqual("http://i4.mangareader.net/naruto/1/naruto-1564774.jpg", images.ToArray()[1]);
@@ -66,7 +66,7 @@ namespace MangaRipper.Test
             var chapter = chapters.Last();
             Assert.AreEqual("Tian Jiang Xian Shu Nan 1", chapter.Name);
             Assert.AreEqual("http://mangafox.me/manga/tian_jiang_xian_shu_nan/c001/1.html", chapter.Url);
-            var images = await service.FindImanges(chapter, new Progress<int>(), _source.Token);
+            var images = await service.FindImages(chapter, new Progress<int>(), _source.Token);
             Assert.AreEqual(15, images.Count());
             Assert.IsTrue(images.ToArray()[0].StartsWith("http://h.mfcdn.net/store/manga/19803/001.0/compressed/q001.jpg"));
             Assert.IsTrue(images.ToArray()[1].StartsWith("http://h.mfcdn.net/store/manga/19803/001.0/compressed/q002.jpg"));
@@ -87,7 +87,7 @@ namespace MangaRipper.Test
             var chapter = chapters.Last();
             Assert.AreEqual("The God Of High School 1", chapter.Name);
             Assert.AreEqual("http://www.mangahere.co/manga/the_god_of_high_school/c001/", chapter.Url);
-            var images = await service.FindImanges(chapter, new Progress<int>(), _source.Token);
+            var images = await service.FindImages(chapter, new Progress<int>(), _source.Token);
             Assert.AreEqual(55, images.Count());
             Assert.IsTrue(images.ToArray()[0].StartsWith("http://h.mhcdn.net/store/manga/9275/001.0/compressed/m001.01.jpg"));
             Assert.IsTrue(images.ToArray()[1].StartsWith("http://h.mhcdn.net/store/manga/9275/001.0/compressed/m001.02.jpg"));
@@ -108,7 +108,7 @@ namespace MangaRipper.Test
             var chapter = chapters.Last();
             Assert.AreEqual("Gantz 1", chapter.Name);
             Assert.AreEqual("http://read.mangashare.com/Gantz/chapter-001/page001.html", chapter.Url);
-            var images = await service.FindImanges(chapter, new Progress<int>(), _source.Token);
+            var images = await service.FindImages(chapter, new Progress<int>(), _source.Token);
             Assert.AreEqual(43, images.Count());
             Assert.AreEqual("http://dl01.mangashare.com/manga/Gantz/001/001.jpg", images.ToArray()[0]);
             Assert.AreEqual("http://dl01.mangashare.com/manga/Gantz/001/002.jpg", images.ToArray()[1]);
@@ -129,7 +129,7 @@ namespace MangaRipper.Test
             var chapter = chapters.Last();
             Assert.AreEqual("Vol.01 Ch.01 Read Online", chapter.Name);
             Assert.AreEqual("http://bato.to/reader#900d11d96d1466f2", chapter.Url);
-            var images = await service.FindImanges(chapter, new Progress<int>(), _source.Token);
+            var images = await service.FindImages(chapter, new Progress<int>(), _source.Token);
             Assert.AreEqual(31, images.Count());
             Assert.IsTrue(images.ToArray()[0].StartsWith("http://img.bato.to/comics/2014/10/08/2/read54357eb5e1ca9/img000001.jpg"));
             Assert.IsTrue(images.ToArray()[1].StartsWith("http://img.bato.to/comics/2014/10/08/2/read54357eb5e1ca9/img000002.jpg"));
@@ -151,7 +151,7 @@ namespace MangaRipper.Test
             var chapter = chapters.Last();
             Assert.AreEqual("001 - The God of Destruction's Prophetic Dream", chapter.Name);
             Assert.AreEqual("http://mangastream.com/r/dragon_ball_super/001/2831/1", chapter.Url);
-            var images = await service.FindImanges(chapter, new Progress<int>(), _source.Token);
+            var images = await service.FindImages(chapter, new Progress<int>(), _source.Token);
             Assert.AreEqual(17, images.Count());
             Assert.IsTrue(images.ToArray()[0].StartsWith("http://img.mangastream.com/cdn/manga/107/2831/001.jpg"));
             Assert.IsTrue(images.ToArray()[1].StartsWith("http://img.mangastream.com/cdn/manga/107/2831/001a.jpg"));
@@ -175,7 +175,7 @@ namespace MangaRipper.Test
             var chapter = chapters.Last();
             Assert.AreEqual("Onepunch-Man _vol.001 ch.001", chapter.Name);
             Assert.AreEqual("http://kissmanga.com/Manga/Onepunch-Man/vol-001-ch-001?id=313725", chapter.Url);
-            var images = await service.FindImanges(chapter, new Progress<int>(), _source.Token);
+            var images = await service.FindImages(chapter, new Progress<int>(), _source.Token);
             Assert.AreEqual(19, images.Count());
             Assert.IsTrue(images.ToArray()[0].StartsWith("https://images1-focus-opensocial.googleusercontent.com/gadgets/proxy?container=focus&gadget=a&no_expand=1&resize_h=0&rewriteMime=image%2F*&url=http%3a%2f%2f2.p.mpcdn.net%2f50%2f531513%2f1.jpg&imgmax=30000"));
             Assert.IsTrue(images.ToArray()[1].StartsWith("https://images1-focus-opensocial.googleusercontent.com/gadgets/proxy?container=focus&gadget=a&no_expand=1&resize_h=0&rewriteMime=image%2F*&url=http%3a%2f%2f2.p.mpcdn.net%2f50%2f531513%2f2.jpg&imgmax=30000"));

--- a/MangaRipper/Forms/FormMain.cs
+++ b/MangaRipper/Forms/FormMain.cs
@@ -234,7 +234,7 @@ namespace MangaRipper.Forms
                 Logger.Info($"Local version: {Application.ProductVersion}. Remote version: {latestVersion}");
                                 
                 if (MessageBox.Show(
-                    $"There's new version ({latestVersion}). Click OK to open download page.",
+                    $"There's a new version: ({latestVersion}) - Click OK to open download page.",
                     Application.ProductName,
                     MessageBoxButtons.OKCancel,
                     MessageBoxIcon.Information) == System.Windows.Forms.DialogResult.OK)

--- a/MangaRipper/Forms/FormMain.cs
+++ b/MangaRipper/Forms/FormMain.cs
@@ -226,13 +226,21 @@ namespace MangaRipper.Forms
         {
             if (Application.ProductVersion == "1.0.0.0")
                 return;
+
             var latestVersion = await UpdateNotification.GetLatestVersion();
             if (UpdateNotification.GetLatestBuildNumber(latestVersion) >
                 UpdateNotification.GetLatestBuildNumber(Application.ProductVersion))
             {
                 Logger.Info($"Local version: {Application.ProductVersion}. Remote version: {latestVersion}");
-                MessageBox.Show($"There's new version ({latestVersion}). Click OK to open download page.");
-                Process.Start("https://github.com/NguyenDanPhuong/MangaRipper/releases");
+                                
+                if (MessageBox.Show(
+                    $"There's new version ({latestVersion}). Click OK to open download page.",
+                    Application.ProductName,
+                    MessageBoxButtons.OKCancel,
+                    MessageBoxIcon.Information) == System.Windows.Forms.DialogResult.OK)
+                {
+                    Process.Start("https://github.com/NguyenDanPhuong/MangaRipper/releases");
+                }
             }
         }
 


### PR DESCRIPTION
#56: Fixed the regex pattern to fetch chapters in the KissManga plugin; tested with Detective Conan, all the chapters are loaded.

Users can now click 'Cancel' when upon prompting to update.

Fixed a possible typo, 'FindImanges' is now 'FindImages'.