### PR TITLE
Series-specific save destination

### DIFF
--- a/MangaRipper.Core/Extensions/ExtensionHelper.cs
+++ b/MangaRipper.Core/Extensions/ExtensionHelper.cs
@@ -34,5 +34,23 @@ namespace MangaRipper.Core.Extensions
             foreach (FileInfo file in source.GetFiles())
                 file.CopyTo(Path.Combine(destination.FullName, file.Name));
         }
+
+        /// <summary>
+        /// Replaces the user's name with a generic placeholder to protect their privacy.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static string SanitizeUserName(string input)
+        {
+            if (!string.IsNullOrWhiteSpace(input))
+            {
+                return input.Replace(System.Environment.UserName, "<user>");
+            }
+            else
+            {
+                throw new System.ArgumentNullException("Value cannot be null.");
+            }
+
+        }
     }
 }

--- a/MangaRipper.Core/Helpers/ParserHelper.cs
+++ b/MangaRipper.Core/Helpers/ParserHelper.cs
@@ -47,7 +47,7 @@ namespace MangaRipper.Core.Helpers
                 list.Add(chapter);
             }
             var result = list.Distinct().ToList();
-            Logger.Info($@"Parse success. There are {result.Count()} item(s).");
+            Logger.Info($@"Parse success. There are {result.Count} item(s).");
             return result;
         }
 

--- a/MangaRipper.Plugin.KissManga/KissManga.cs
+++ b/MangaRipper.Plugin.KissManga/KissManga.cs
@@ -20,7 +20,7 @@ namespace MangaRipper.Plugin.KissManga
     {
         private static Logger _logger = LogManager.GetCurrentClassLogger();
         private string _iv = "a5e8e2e9c2721be0a84ad660c472c1f3";
-        private string _chko = "72nnasdasd9asdn123";
+        private string _chko = "nsfd732nsdnds823nsdf";
 
         private KissMangaTextDecryption _decryptor;
 

--- a/MangaRipper.Plugin.MangaStream/MangaStream.cs
+++ b/MangaRipper.Plugin.MangaStream/MangaStream.cs
@@ -27,7 +27,7 @@ namespace MangaRipper.Plugin.MangaStream
             progress.Report(0);
             // find all chapters in a manga
             string input = await downloader.DownloadStringAsync(manga);
-            string regEx = "<td><a href=\"(?<Value>http://mangastream.com/r/[^\"]+)\">(?<Name>[^<]+)</a>";
+            string regEx = "<td><a href=\"(?<Value>http://readms.net/r/[^\"]+)\">(?<Name>[^<]+)</a>";
             var chaps = parser.ParseGroup(regEx, input, "Name", "Value");
             progress.Report(100);
             return chaps;
@@ -42,7 +42,7 @@ namespace MangaRipper.Plugin.MangaStream
             // find all pages in a chapter
             string input = await downloader.DownloadStringAsync(chapter.Url);
             string regExPages =
-                "<li><a href=\"(?<Value>http://mangastream.com/r/[^\"]+)\">[^<]+</a>";
+                "<li><a href=\"(?<Value>http://readms.com/r/[^\"]+)\">[^<]+</a>";
             var pages = parser.Parse(regExPages, input, "Value");
 
             // find all images in pages

--- a/MangaRipper.Plugin.ReadComics/MangaRipper.Plugin.ReadComics.csproj
+++ b/MangaRipper.Plugin.ReadComics/MangaRipper.Plugin.ReadComics.csproj
@@ -31,6 +31,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.4.1\lib\net45\NLog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -50,7 +54,15 @@
       <Name>MangaRipper.Core</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>if not exist "$(SolutionDir)\ReadComics\$(OutDir)Plugins\" mkdir "$(SolutionDir)\ReadComics\$(OutDir)Plugins\"
+copy /Y "$(TargetDir)$(TargetName).dll" "$(SolutionDir)\MangaRipper\$(OutDir)Plugins\$(TargetName).dll"
+copy /Y "$(TargetDir)$(TargetName).pdb" "$(SolutionDir)\MangaRipper\$(OutDir)Plugins\$(TargetName).pdb"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/MangaRipper.Plugin.ReadComics/MangaRipper.Plugin.ReadComics.csproj
+++ b/MangaRipper.Plugin.ReadComics/MangaRipper.Plugin.ReadComics.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D45675A2-8920-4FA5-8B89-C15C2958E765}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MangaRipper.Plugin.ReadComics</RootNamespace>
+    <AssemblyName>MangaRipper.Plugin.ReadComics</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ReadComics.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MangaRipper.Core\MangaRipper.Core.csproj">
+      <Project>{13effe36-dbb8-4573-9260-b601177f66e3}</Project>
+      <Name>MangaRipper.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/MangaRipper.Plugin.ReadComics/Properties/AssemblyInfo.cs
+++ b/MangaRipper.Plugin.ReadComics/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MangaRipper.Plugin.ReadComics")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MangaRipper.Plugin.ReadComics")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d45675a2-8920-4fa5-8b89-c15c2958e765")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/MangaRipper.Plugin.ReadComics/ReadComics.cs
+++ b/MangaRipper.Plugin.ReadComics/ReadComics.cs
@@ -37,19 +37,13 @@ namespace MangaRipper.Plugin.ReadComics
             try
             {
                 string html = await downloader.DownloadStringAsync(manga);
-
-                Logger.Info("> Retrieved HTML source.");
-
+                
                 progress.Report(50);
 
                 string pattern = "<a\\s+class=\"ch-name\"\\s+href=\"(?<Value>.[^\"]*)\">(?<Name>.*)(?=\\<)";
-
-                Logger.Debug($"> Scraping chapters with \"{pattern}\"");
-
+                
                 var chapters = parser.ParseGroup(pattern, html, "Name", "Value");
-
-                Logger.Info($"> Found {((List<Chapter>)chapters).Count} chapters.");
-
+                
                 progress.Report(90);
 
                 ((List<Chapter>)chapters).Reverse();
@@ -85,12 +79,8 @@ namespace MangaRipper.Plugin.ReadComics
                 if (!string.IsNullOrWhiteSpace(html))
                 {
                     string pattern = "<img\\s+class=\"chapter_img\".*src=\"(?<Value>.[^\"]*)";
-
-                    Logger.Debug($"Scraping images with \"{pattern}\"");
-
+                    
                     var pages = parser.Parse(pattern, html, "Value");
-
-                    Logger.Info($"> Found {((List<string>)pages).Count} pages.");
 
                     return pages;
                 }

--- a/MangaRipper.Plugin.ReadComics/ReadComics.cs
+++ b/MangaRipper.Plugin.ReadComics/ReadComics.cs
@@ -1,0 +1,120 @@
+﻿using MangaRipper.Core.Helpers;
+using MangaRipper.Core.Interfaces;
+using MangaRipper.Core.Models;
+
+using MangaRipper.Core.Services;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace MangaRipper.Plugin.ReadComics
+{
+    public class ReadComics : MangaService
+    {
+        /* 
+         * Author: Jed Burke
+         * Acknowledging that this is mostly a copy-paste job of MangaFox.cs
+         * 
+         * Series tested:
+         *  http://readcomics.tv/comic/teen-titans-go-2013
+         *  
+         */
+
+        static readonly string Host = "readcomics.tv";
+
+        public override async Task<IEnumerable<Chapter>> FindChapters(string manga, IProgress<int> progress, CancellationToken cancellationToken)
+        {
+            progress.Report(0);
+
+            var downloader = new DownloadService();
+            var parser = new ParserHelper();
+
+            try
+            {
+                string html = await downloader.DownloadStringAsync(manga);
+
+                progress.Report(50);
+
+                string pattern = "<a\\s+class=\"ch-name\"\\s+href=\"(?<Value>.[^\"]*)\">(?<Name>.*)(?=\\<)";
+
+                var chapters = parser.ParseGroup(pattern, html, "Name", "Value");
+
+                progress.Report(90);
+
+                ((List<Chapter>)chapters).Reverse();
+
+                progress.Report(100);
+
+                return chapters;
+            }
+            finally
+            {
+                downloader = null;
+                parser = null;
+            }
+
+        }
+
+        public override async Task<IEnumerable<string>> FindImages(Chapter chapter, IProgress<int> progress, CancellationToken cancellationToken)
+        {
+            progress.Report(0);
+            var downloader = new DownloadService();
+            var parser = new ParserHelper();
+            string
+                html,
+                chapterUrl;
+
+            try
+            {
+                chapterUrl = string.Concat(chapter.Url, "/full");
+                html = await downloader.DownloadStringAsync(chapterUrl);
+
+                if (!string.IsNullOrWhiteSpace(html))
+                {
+                    string pattern = "<img\\s+class=\"chapter_img\".*src=\"(?<Value>.[^\"]*)";
+                    var pages = parser.Parse(pattern, html, "Value");
+
+                    return pages;
+                }
+
+            }
+            finally
+            {
+                downloader = null;
+                parser = null;
+                html = null;
+                chapterUrl = null;
+            }
+
+            throw new Core.CustomException.MangaRipperException("Can't return pages.");
+        }
+
+        public override SiteInformation GetInformation()
+        {
+            return new SiteInformation(nameof(ReadComics), Host, "English");
+        }
+
+        public override bool Of(string link)
+        {
+            Uri uri;
+
+            try
+            {
+                if (Uri.TryCreate(link, UriKind.Absolute, out uri))
+                {
+                    return (string.Compare(uri.Host, Host, true, System.Globalization.CultureInfo.InvariantCulture) == 0);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            finally
+            {
+                uri = null;
+            }
+
+        }
+    }
+}

--- a/MangaRipper.Plugin.ReadComics/packages.config
+++ b/MangaRipper.Plugin.ReadComics/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NLog" version="4.4.1" targetFramework="net452" />
+</packages>

--- a/MangaRipper.sln
+++ b/MangaRipper.sln
@@ -8,6 +8,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MangaRipper.Core", "MangaRipper.Core\MangaRipper.Core.csproj", "{13EFFE36-DBB8-4573-9260-B601177F66E3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MangaRipper.Test", "MangaRipper.Test\MangaRipper.Test.csproj", "{CF6D034E-8BFD-4799-AEFD-2589F58D1C1A}"
+	ProjectSection(ProjectDependencies) = postProject
+		{D45675A2-8920-4FA5-8B89-C15C2958E765} = {D45675A2-8920-4FA5-8B89-C15C2958E765}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MangaRipper.Plugin.MangaFox", "MangaRipper.Plugin.MangaFox\MangaRipper.Plugin.MangaFox.csproj", "{F5D529B4-CBB6-46E2-9D32-25CEF8365318}"
 EndProject
@@ -24,6 +27,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Plugins", "Plugins", "{AA38E249-11BB-4145-A06C-F51D281497F5}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MangaRipper.Plugin.MangaStream", "MangaRipper.Plugin.MangaStream\MangaRipper.Plugin.MangaStream.csproj", "{746524A7-E0EE-4240-A9A2-DD7BCCBCCF5B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MangaRipper.Plugin.ReadComics", "MangaRipper.Plugin.ReadComics\MangaRipper.Plugin.ReadComics.csproj", "{D45675A2-8920-4FA5-8B89-C15C2958E765}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -151,6 +156,18 @@ Global
 		{746524A7-E0EE-4240-A9A2-DD7BCCBCCF5B}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{746524A7-E0EE-4240-A9A2-DD7BCCBCCF5B}.Release|x86.ActiveCfg = Release|Any CPU
 		{746524A7-E0EE-4240-A9A2-DD7BCCBCCF5B}.Release|x86.Build.0 = Release|Any CPU
+		{D45675A2-8920-4FA5-8B89-C15C2958E765}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D45675A2-8920-4FA5-8B89-C15C2958E765}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D45675A2-8920-4FA5-8B89-C15C2958E765}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{D45675A2-8920-4FA5-8B89-C15C2958E765}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{D45675A2-8920-4FA5-8B89-C15C2958E765}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D45675A2-8920-4FA5-8B89-C15C2958E765}.Debug|x86.Build.0 = Debug|Any CPU
+		{D45675A2-8920-4FA5-8B89-C15C2958E765}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D45675A2-8920-4FA5-8B89-C15C2958E765}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D45675A2-8920-4FA5-8B89-C15C2958E765}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{D45675A2-8920-4FA5-8B89-C15C2958E765}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{D45675A2-8920-4FA5-8B89-C15C2958E765}.Release|x86.ActiveCfg = Release|Any CPU
+		{D45675A2-8920-4FA5-8B89-C15C2958E765}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -163,6 +180,7 @@ Global
 		{A156FB0B-1E4A-4DB0-B944-D23413CA8D58} = {AA38E249-11BB-4145-A06C-F51D281497F5}
 		{CE21343F-3C7F-4161-94A5-3A7CCDD9CF01} = {AA38E249-11BB-4145-A06C-F51D281497F5}
 		{746524A7-E0EE-4240-A9A2-DD7BCCBCCF5B} = {AA38E249-11BB-4145-A06C-F51D281497F5}
+		{D45675A2-8920-4FA5-8B89-C15C2958E765} = {AA38E249-11BB-4145-A06C-F51D281497F5}
 	EndGlobalSection
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = MangaRipper.vsmdi

--- a/MangaRipper/Forms/FormMain.Designer.cs
+++ b/MangaRipper/Forms/FormMain.Designer.cs
@@ -62,8 +62,6 @@
             this.lbDefaultDestination = new System.Windows.Forms.Label();
             this.lbSeriesDestination = new System.Windows.Forms.Label();
             this.txtMessage = new System.Windows.Forms.TextBox();
-            this.cbSaveFolder = new System.Windows.Forms.CheckBox();
-            this.cbSaveCbz = new System.Windows.Forms.CheckBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
@@ -77,6 +75,11 @@
             this.rdDefaultDestination = new System.Windows.Forms.RadioButton();
             this.rdSeriesDestination = new System.Windows.Forms.RadioButton();
             this.lbDestination = new System.Windows.Forms.Label();
+            this.cbUseSeriesFolder = new System.Windows.Forms.CheckBox();
+            this.rbSaveFolder = new System.Windows.Forms.RadioButton();
+            this.rbSaveCbz = new System.Windows.Forms.RadioButton();
+            this.cbSaveCbz = new System.Windows.Forms.CheckBox();
+            this.cbSaveFolder = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.dgvQueueChapter)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgvSupportedSites)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgvChapter)).BeginInit();
@@ -289,13 +292,13 @@
             dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.ControlText;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
             this.dgvSupportedSites.DefaultCellStyle = dataGridViewCellStyle1;
-            this.dgvSupportedSites.Location = new System.Drawing.Point(12, 448);
+            this.dgvSupportedSites.Location = new System.Drawing.Point(12, 405);
             this.dgvSupportedSites.MultiSelect = false;
             this.dgvSupportedSites.Name = "dgvSupportedSites";
             this.dgvSupportedSites.ReadOnly = true;
             this.dgvSupportedSites.RowHeadersVisible = false;
             this.dgvSupportedSites.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dgvSupportedSites.Size = new System.Drawing.Size(425, 126);
+            this.dgvSupportedSites.Size = new System.Drawing.Size(425, 169);
             this.dgvSupportedSites.TabIndex = 15;
             this.dgvSupportedSites.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dgvSupportedSites_CellContentClick);
             // 
@@ -395,7 +398,7 @@
             // checkBoxForPrefix
             // 
             this.checkBoxForPrefix.AutoSize = true;
-            this.checkBoxForPrefix.Location = new System.Drawing.Point(6, 18);
+            this.checkBoxForPrefix.Location = new System.Drawing.Point(11, 17);
             this.checkBoxForPrefix.Name = "checkBoxForPrefix";
             this.checkBoxForPrefix.Size = new System.Drawing.Size(99, 17);
             this.checkBoxForPrefix.TabIndex = 0;
@@ -409,7 +412,7 @@
             this.lbDefaultDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.lbDefaultDestination.AutoSize = true;
             this.lbDefaultDestination.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbDefaultDestination.Location = new System.Drawing.Point(55, 319);
+            this.lbDefaultDestination.Location = new System.Drawing.Point(29, 318);
             this.lbDefaultDestination.MaximumSize = new System.Drawing.Size(385, 17);
             this.lbDefaultDestination.MinimumSize = new System.Drawing.Size(64, 17);
             this.lbDefaultDestination.Name = "lbDefaultDestination";
@@ -425,7 +428,7 @@
             this.lbSeriesDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.lbSeriesDestination.AutoSize = true;
             this.lbSeriesDestination.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbSeriesDestination.Location = new System.Drawing.Point(55, 354);
+            this.lbSeriesDestination.Location = new System.Drawing.Point(710, 382);
             this.lbSeriesDestination.MaximumSize = new System.Drawing.Size(380, 17);
             this.lbSeriesDestination.MinimumSize = new System.Drawing.Size(64, 17);
             this.lbSeriesDestination.Name = "lbSeriesDestination";
@@ -445,38 +448,14 @@
             this.txtMessage.Size = new System.Drawing.Size(1004, 22);
             this.txtMessage.TabIndex = 23;
             // 
-            // cbSaveFolder
-            // 
-            this.cbSaveFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.cbSaveFolder.AutoSize = true;
-            this.cbSaveFolder.Checked = true;
-            this.cbSaveFolder.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbSaveFolder.Location = new System.Drawing.Point(4, 18);
-            this.cbSaveFolder.Name = "cbSaveFolder";
-            this.cbSaveFolder.Size = new System.Drawing.Size(59, 17);
-            this.cbSaveFolder.TabIndex = 27;
-            this.cbSaveFolder.Text = "Folder";
-            this.cbSaveFolder.UseVisualStyleBackColor = true;
-            // 
-            // cbSaveCbz
-            // 
-            this.cbSaveCbz.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.cbSaveCbz.AutoSize = true;
-            this.cbSaveCbz.Location = new System.Drawing.Point(71, 18);
-            this.cbSaveCbz.Name = "cbSaveCbz";
-            this.cbSaveCbz.Size = new System.Drawing.Size(46, 17);
-            this.cbSaveCbz.TabIndex = 28;
-            this.cbSaveCbz.Text = "CBZ";
-            this.cbSaveCbz.UseVisualStyleBackColor = true;
-            // 
             // groupBox1
             // 
             this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.groupBox1.Controls.Add(this.cbSaveFolder);
             this.groupBox1.Controls.Add(this.cbSaveCbz);
-            this.groupBox1.Location = new System.Drawing.Point(102, 397);
+            this.groupBox1.Location = new System.Drawing.Point(12, 358);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(118, 41);
+            this.groupBox1.Size = new System.Drawing.Size(161, 41);
             this.groupBox1.TabIndex = 29;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Save As";
@@ -485,9 +464,10 @@
             // 
             this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.groupBox2.Controls.Add(this.checkBoxForPrefix);
-            this.groupBox2.Location = new System.Drawing.Point(226, 397);
+            this.groupBox2.Controls.Add(this.cbUseSeriesFolder);
+            this.groupBox2.Location = new System.Drawing.Point(179, 358);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(120, 41);
+            this.groupBox2.Size = new System.Drawing.Size(258, 41);
             this.groupBox2.TabIndex = 30;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "File manipulation";
@@ -563,7 +543,7 @@
             this.rdDefaultDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.rdDefaultDestination.AutoSize = true;
             this.rdDefaultDestination.Checked = true;
-            this.rdDefaultDestination.Location = new System.Drawing.Point(35, 322);
+            this.rdDefaultDestination.Location = new System.Drawing.Point(690, 353);
             this.rdDefaultDestination.Name = "rdDefaultDestination";
             this.rdDefaultDestination.Size = new System.Drawing.Size(14, 13);
             this.rdDefaultDestination.TabIndex = 32;
@@ -574,7 +554,7 @@
             // 
             this.rdSeriesDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.rdSeriesDestination.AutoSize = true;
-            this.rdSeriesDestination.Location = new System.Drawing.Point(35, 357);
+            this.rdSeriesDestination.Location = new System.Drawing.Point(690, 385);
             this.rdSeriesDestination.Name = "rdSeriesDestination";
             this.rdSeriesDestination.Size = new System.Drawing.Size(14, 13);
             this.rdSeriesDestination.TabIndex = 33;
@@ -591,12 +571,72 @@
             this.lbDestination.TabIndex = 26;
             this.lbDestination.Text = "Save Destination";
             // 
+            // cbUseSeriesFolder
+            // 
+            this.cbUseSeriesFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.cbUseSeriesFolder.AutoSize = true;
+            this.cbUseSeriesFolder.Location = new System.Drawing.Point(116, 17);
+            this.cbUseSeriesFolder.Name = "cbUseSeriesFolder";
+            this.cbUseSeriesFolder.Size = new System.Drawing.Size(131, 17);
+            this.cbUseSeriesFolder.TabIndex = 29;
+            this.cbUseSeriesFolder.Text = "Save in Series Folder";
+            this.toolTip1.SetToolTip(this.cbUseSeriesFolder, "Save chapters in \'D:\\Manga\\Detective Conan\'");
+            this.cbUseSeriesFolder.UseVisualStyleBackColor = true;
+            // 
+            // rbSaveFolder
+            // 
+            this.rbSaveFolder.AutoSize = true;
+            this.rbSaveFolder.Checked = true;
+            this.rbSaveFolder.Location = new System.Drawing.Point(692, 319);
+            this.rbSaveFolder.Name = "rbSaveFolder";
+            this.rbSaveFolder.Size = new System.Drawing.Size(58, 17);
+            this.rbSaveFolder.TabIndex = 36;
+            this.rbSaveFolder.TabStop = true;
+            this.rbSaveFolder.Text = "Folder";
+            this.rbSaveFolder.UseVisualStyleBackColor = true;
+            // 
+            // rbSaveCbz
+            // 
+            this.rbSaveCbz.AutoSize = true;
+            this.rbSaveCbz.Location = new System.Drawing.Point(756, 318);
+            this.rbSaveCbz.Name = "rbSaveCbz";
+            this.rbSaveCbz.Size = new System.Drawing.Size(45, 17);
+            this.rbSaveCbz.TabIndex = 37;
+            this.rbSaveCbz.Text = "CBZ";
+            this.rbSaveCbz.UseVisualStyleBackColor = true;
+            // 
+            // cbSaveCbz
+            // 
+            this.cbSaveCbz.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.cbSaveCbz.AutoSize = true;
+            this.cbSaveCbz.Location = new System.Drawing.Point(90, 17);
+            this.cbSaveCbz.Name = "cbSaveCbz";
+            this.cbSaveCbz.Size = new System.Drawing.Size(46, 17);
+            this.cbSaveCbz.TabIndex = 28;
+            this.cbSaveCbz.Text = "CBZ";
+            this.cbSaveCbz.UseVisualStyleBackColor = true;
+            // 
+            // cbSaveFolder
+            // 
+            this.cbSaveFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.cbSaveFolder.AutoSize = true;
+            this.cbSaveFolder.Checked = true;
+            this.cbSaveFolder.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbSaveFolder.Location = new System.Drawing.Point(25, 17);
+            this.cbSaveFolder.Name = "cbSaveFolder";
+            this.cbSaveFolder.Size = new System.Drawing.Size(59, 17);
+            this.cbSaveFolder.TabIndex = 27;
+            this.cbSaveFolder.Text = "Folder";
+            this.cbSaveFolder.UseVisualStyleBackColor = true;
+            // 
             // FormMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1004, 606);
+            this.Controls.Add(this.rbSaveCbz);
             this.Controls.Add(this.lbSeriesDestination);
+            this.Controls.Add(this.rbSaveFolder);
             this.Controls.Add(this.lbDefaultDestination);
             this.Controls.Add(this.lbDestination);
             this.Controls.Add(this.rdSeriesDestination);
@@ -670,8 +710,6 @@
         private System.Windows.Forms.Button btnRemoveBookmark;
         private System.Windows.Forms.ToolTip toolTip1;
         private System.Windows.Forms.TextBox txtMessage;
-        private System.Windows.Forms.CheckBox cbSaveFolder;
-        private System.Windows.Forms.CheckBox cbSaveCbz;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColChapterName;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColChapterStatus;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColChapterUrl;
@@ -692,5 +730,10 @@
         private System.Windows.Forms.Label lbDestination;
         private System.Windows.Forms.Label lbDefaultDestination;
         private System.Windows.Forms.Label lbSeriesDestination;
+        private System.Windows.Forms.CheckBox cbUseSeriesFolder;
+        private System.Windows.Forms.RadioButton rbSaveCbz;
+        private System.Windows.Forms.RadioButton rbSaveFolder;
+        private System.Windows.Forms.CheckBox cbSaveCbz;
+        private System.Windows.Forms.CheckBox cbSaveFolder;
     }
 }

--- a/MangaRipper/Forms/FormMain.Designer.cs
+++ b/MangaRipper/Forms/FormMain.Designer.cs
@@ -45,7 +45,6 @@
             this.btnStop = new System.Windows.Forms.Button();
             this.btnChangeSaveTo = new System.Windows.Forms.Button();
             this.btnOpenFolder = new System.Windows.Forms.Button();
-            this.lbSaveTo = new System.Windows.Forms.Label();
             this.lblUrl = new System.Windows.Forms.Label();
             this.txtPercent = new System.Windows.Forms.TextBox();
             this.dgvSupportedSites = new System.Windows.Forms.DataGridView();
@@ -54,13 +53,14 @@
             this.Column1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dgvChapter = new System.Windows.Forms.DataGridView();
             this.dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.folderBrowserDialog1 = new System.Windows.Forms.FolderBrowserDialog();
+            this.saveDestinationDirectoryBrowser = new System.Windows.Forms.FolderBrowserDialog();
             this.cbTitleUrl = new System.Windows.Forms.ComboBox();
             this.btnAddBookmark = new System.Windows.Forms.Button();
             this.btnRemoveBookmark = new System.Windows.Forms.Button();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.checkBoxForPrefix = new System.Windows.Forms.CheckBox();
-            this.txtSaveTo = new System.Windows.Forms.TextBox();
+            this.lbDefaultDestination = new System.Windows.Forms.Label();
+            this.lbSeriesDestination = new System.Windows.Forms.Label();
             this.txtMessage = new System.Windows.Forms.TextBox();
             this.cbSaveFolder = new System.Windows.Forms.CheckBox();
             this.cbSaveCbz = new System.Windows.Forms.CheckBox();
@@ -74,6 +74,9 @@
             this.wikiToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.bugReportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.rdDefaultDestination = new System.Windows.Forms.RadioButton();
+            this.rdSeriesDestination = new System.Windows.Forms.RadioButton();
+            this.lbDestination = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.dgvQueueChapter)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgvSupportedSites)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgvChapter)).BeginInit();
@@ -246,16 +249,6 @@
             this.btnOpenFolder.UseVisualStyleBackColor = true;
             this.btnOpenFolder.Click += new System.EventHandler(this.btnOpenFolder_Click);
             // 
-            // lbSaveTo
-            // 
-            this.lbSaveTo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.lbSaveTo.AutoSize = true;
-            this.lbSaveTo.Location = new System.Drawing.Point(12, 292);
-            this.lbSaveTo.Name = "lbSaveTo";
-            this.lbSaveTo.Size = new System.Drawing.Size(44, 13);
-            this.lbSaveTo.TabIndex = 11;
-            this.lbSaveTo.Text = "Save To";
-            // 
             // lblUrl
             // 
             this.lblUrl.AutoSize = true;
@@ -296,13 +289,13 @@
             dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.ControlText;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
             this.dgvSupportedSites.DefaultCellStyle = dataGridViewCellStyle1;
-            this.dgvSupportedSites.Location = new System.Drawing.Point(12, 375);
+            this.dgvSupportedSites.Location = new System.Drawing.Point(12, 448);
             this.dgvSupportedSites.MultiSelect = false;
             this.dgvSupportedSites.Name = "dgvSupportedSites";
             this.dgvSupportedSites.ReadOnly = true;
             this.dgvSupportedSites.RowHeadersVisible = false;
             this.dgvSupportedSites.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dgvSupportedSites.Size = new System.Drawing.Size(425, 199);
+            this.dgvSupportedSites.Size = new System.Drawing.Size(425, 126);
             this.dgvSupportedSites.TabIndex = 15;
             this.dgvSupportedSites.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dgvSupportedSites_CellContentClick);
             // 
@@ -411,14 +404,35 @@
             this.checkBoxForPrefix.UseVisualStyleBackColor = true;
             this.checkBoxForPrefix.CheckedChanged += new System.EventHandler(this.checkBoxForPrefix_CheckedChanged);
             // 
-            // txtSaveTo
+            // lbDefaultDestination
             // 
-            this.txtSaveTo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.txtSaveTo.Location = new System.Drawing.Point(66, 289);
-            this.txtSaveTo.Name = "txtSaveTo";
-            this.txtSaveTo.ReadOnly = true;
-            this.txtSaveTo.Size = new System.Drawing.Size(240, 22);
-            this.txtSaveTo.TabIndex = 12;
+            this.lbDefaultDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.lbDefaultDestination.AutoSize = true;
+            this.lbDefaultDestination.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbDefaultDestination.Location = new System.Drawing.Point(55, 323);
+            this.lbDefaultDestination.MaximumSize = new System.Drawing.Size(385, 17);
+            this.lbDefaultDestination.MinimumSize = new System.Drawing.Size(380, 17);
+            this.lbDefaultDestination.Name = "lbDefaultDestination";
+            this.lbDefaultDestination.Size = new System.Drawing.Size(380, 17);
+            this.lbDefaultDestination.TabIndex = 34;
+            this.lbDefaultDestination.Text = "Default Destination";
+            this.toolTip1.SetToolTip(this.lbDefaultDestination, "Saves the chapter to the default manga folder");
+            this.lbDefaultDestination.UseMnemonic = false;
+            // 
+            // lbSeriesDestination
+            // 
+            this.lbSeriesDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.lbSeriesDestination.AutoSize = true;
+            this.lbSeriesDestination.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbSeriesDestination.Location = new System.Drawing.Point(55, 358);
+            this.lbSeriesDestination.MaximumSize = new System.Drawing.Size(380, 17);
+            this.lbSeriesDestination.MinimumSize = new System.Drawing.Size(380, 17);
+            this.lbSeriesDestination.Name = "lbSeriesDestination";
+            this.lbSeriesDestination.Size = new System.Drawing.Size(380, 17);
+            this.lbSeriesDestination.TabIndex = 35;
+            this.lbSeriesDestination.Text = "Series Specific Destination";
+            this.toolTip1.SetToolTip(this.lbSeriesDestination, "Saves the chapter to the series\' folder");
+            this.lbSeriesDestination.UseMnemonic = false;
             // 
             // txtMessage
             // 
@@ -458,7 +472,7 @@
             this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.groupBox1.Controls.Add(this.cbSaveFolder);
             this.groupBox1.Controls.Add(this.cbSaveCbz);
-            this.groupBox1.Location = new System.Drawing.Point(15, 317);
+            this.groupBox1.Location = new System.Drawing.Point(12, 401);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(118, 41);
             this.groupBox1.TabIndex = 29;
@@ -469,7 +483,7 @@
             // 
             this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.groupBox2.Controls.Add(this.checkBoxForPrefix);
-            this.groupBox2.Location = new System.Drawing.Point(139, 317);
+            this.groupBox2.Location = new System.Drawing.Point(136, 401);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Size = new System.Drawing.Size(120, 41);
             this.groupBox2.TabIndex = 30;
@@ -501,14 +515,14 @@
             // dataToolStripMenuItem
             // 
             this.dataToolStripMenuItem.Name = "dataToolStripMenuItem";
-            this.dataToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.dataToolStripMenuItem.Size = new System.Drawing.Size(99, 22);
             this.dataToolStripMenuItem.Text = "Data";
             this.dataToolStripMenuItem.Click += new System.EventHandler(this.dataToolStripMenuItem_Click);
             // 
             // logsToolStripMenuItem
             // 
             this.logsToolStripMenuItem.Name = "logsToolStripMenuItem";
-            this.logsToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.logsToolStripMenuItem.Size = new System.Drawing.Size(99, 22);
             this.logsToolStripMenuItem.Text = "Logs";
             this.logsToolStripMenuItem.Click += new System.EventHandler(this.logsToolStripMenuItem_Click);
             // 
@@ -524,14 +538,14 @@
             // wikiToolStripMenuItem
             // 
             this.wikiToolStripMenuItem.Name = "wikiToolStripMenuItem";
-            this.wikiToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.wikiToolStripMenuItem.Size = new System.Drawing.Size(133, 22);
             this.wikiToolStripMenuItem.Text = "Wiki";
             this.wikiToolStripMenuItem.Click += new System.EventHandler(this.wikiToolStripMenuItem_Click);
             // 
             // bugReportToolStripMenuItem
             // 
             this.bugReportToolStripMenuItem.Name = "bugReportToolStripMenuItem";
-            this.bugReportToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.bugReportToolStripMenuItem.Size = new System.Drawing.Size(133, 22);
             this.bugReportToolStripMenuItem.Text = "Bug Report";
             this.bugReportToolStripMenuItem.Click += new System.EventHandler(this.bugReportToolStripMenuItem_Click);
             // 
@@ -542,23 +556,58 @@
             this.aboutToolStripMenuItem.Text = "About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
+            // rdDefaultDestination
+            // 
+            this.rdDefaultDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.rdDefaultDestination.AutoSize = true;
+            this.rdDefaultDestination.Checked = true;
+            this.rdDefaultDestination.Location = new System.Drawing.Point(35, 326);
+            this.rdDefaultDestination.Name = "rdDefaultDestination";
+            this.rdDefaultDestination.Size = new System.Drawing.Size(14, 13);
+            this.rdDefaultDestination.TabIndex = 32;
+            this.rdDefaultDestination.TabStop = true;
+            this.rdDefaultDestination.UseVisualStyleBackColor = true;
+            // 
+            // rdSeriesDestination
+            // 
+            this.rdSeriesDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.rdSeriesDestination.AutoSize = true;
+            this.rdSeriesDestination.Location = new System.Drawing.Point(35, 361);
+            this.rdSeriesDestination.Name = "rdSeriesDestination";
+            this.rdSeriesDestination.Size = new System.Drawing.Size(14, 13);
+            this.rdSeriesDestination.TabIndex = 33;
+            this.rdSeriesDestination.UseVisualStyleBackColor = true;
+            // 
+            // lbDestination
+            // 
+            this.lbDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.lbDestination.AutoSize = true;
+            this.lbDestination.Font = new System.Drawing.Font("Segoe UI Semibold", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbDestination.Location = new System.Drawing.Point(11, 291);
+            this.lbDestination.Name = "lbDestination";
+            this.lbDestination.Size = new System.Drawing.Size(123, 20);
+            this.lbDestination.TabIndex = 26;
+            this.lbDestination.Text = "Save Destination";
+            // 
             // FormMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1004, 606);
+            this.Controls.Add(this.lbSeriesDestination);
+            this.Controls.Add(this.lbDefaultDestination);
+            this.Controls.Add(this.lbDestination);
+            this.Controls.Add(this.rdSeriesDestination);
+            this.Controls.Add(this.rdDefaultDestination);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.txtMessage);
             this.Controls.Add(this.btnRemoveBookmark);
             this.Controls.Add(this.btnAddBookmark);
             this.Controls.Add(this.cbTitleUrl);
-            this.Controls.Add(this.dgvChapter);
             this.Controls.Add(this.dgvSupportedSites);
             this.Controls.Add(this.txtPercent);
             this.Controls.Add(this.lblUrl);
-            this.Controls.Add(this.txtSaveTo);
-            this.Controls.Add(this.lbSaveTo);
             this.Controls.Add(this.btnChangeSaveTo);
             this.Controls.Add(this.btnStop);
             this.Controls.Add(this.btnOpenFolder);
@@ -570,6 +619,7 @@
             this.Controls.Add(this.btnGetChapter);
             this.Controls.Add(this.dgvQueueChapter);
             this.Controls.Add(this.menuStrip1);
+            this.Controls.Add(this.dgvChapter);
             this.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip1;
@@ -600,17 +650,15 @@
         private System.Windows.Forms.Button btnRemove;
         private System.Windows.Forms.Button btnRemoveAll;
         private System.Windows.Forms.DataGridView dgvQueueChapter;
-        private System.Windows.Forms.TextBox txtSaveTo;
         private System.Windows.Forms.Button btnStop;
         private System.Windows.Forms.Button btnChangeSaveTo;
         private System.Windows.Forms.Button btnOpenFolder;
-        private System.Windows.Forms.Label lbSaveTo;
         private System.Windows.Forms.Label lblUrl;
         private System.Windows.Forms.TextBox txtPercent;
         private System.Windows.Forms.DataGridView dgvSupportedSites;
         private System.Windows.Forms.DataGridView dgvChapter;
         private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn4;
-        private System.Windows.Forms.FolderBrowserDialog folderBrowserDialog1;
+        private System.Windows.Forms.FolderBrowserDialog saveDestinationDirectoryBrowser;
         private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn1;
         private System.Windows.Forms.DataGridViewLinkColumn dataGridViewTextBoxColumn3;
         private System.Windows.Forms.DataGridViewTextBoxColumn Column1;
@@ -636,5 +684,10 @@
         private System.Windows.Forms.ToolStripMenuItem wikiToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem bugReportToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
+        private System.Windows.Forms.RadioButton rdDefaultDestination;
+        private System.Windows.Forms.RadioButton rdSeriesDestination;
+        private System.Windows.Forms.Label lbDestination;
+        private System.Windows.Forms.Label lbDefaultDestination;
+        private System.Windows.Forms.Label lbSeriesDestination;
     }
 }

--- a/MangaRipper/Forms/FormMain.Designer.cs
+++ b/MangaRipper/Forms/FormMain.Designer.cs
@@ -57,12 +57,13 @@
             this.cbTitleUrl = new System.Windows.Forms.ComboBox();
             this.btnAddBookmark = new System.Windows.Forms.Button();
             this.btnRemoveBookmark = new System.Windows.Forms.Button();
-            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.FormToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.checkBoxForPrefix = new System.Windows.Forms.CheckBox();
-            this.lbDefaultDestination = new System.Windows.Forms.Label();
-            this.lbSeriesDestination = new System.Windows.Forms.Label();
+            this.cbUseSeriesFolder = new System.Windows.Forms.CheckBox();
             this.txtMessage = new System.Windows.Forms.TextBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.cbSaveFolder = new System.Windows.Forms.CheckBox();
+            this.cbSaveCbz = new System.Windows.Forms.CheckBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.locationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -72,14 +73,8 @@
             this.wikiToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.bugReportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.rdDefaultDestination = new System.Windows.Forms.RadioButton();
-            this.rdSeriesDestination = new System.Windows.Forms.RadioButton();
             this.lbDestination = new System.Windows.Forms.Label();
-            this.cbUseSeriesFolder = new System.Windows.Forms.CheckBox();
-            this.rbSaveFolder = new System.Windows.Forms.RadioButton();
-            this.rbSaveCbz = new System.Windows.Forms.RadioButton();
-            this.cbSaveCbz = new System.Windows.Forms.CheckBox();
-            this.cbSaveFolder = new System.Windows.Forms.CheckBox();
+            this.txtSaveTo = new System.Windows.Forms.TextBox();
             ((System.ComponentModel.ISupportInitialize)(this.dgvQueueChapter)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgvSupportedSites)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgvChapter)).BeginInit();
@@ -96,7 +91,7 @@
             this.btnGetChapter.Size = new System.Drawing.Size(116, 23);
             this.btnGetChapter.TabIndex = 5;
             this.btnGetChapter.Text = "Get Chapters";
-            this.toolTip1.SetToolTip(this.btnGetChapter, "Get Chapters from Inputed Url");
+            this.FormToolTip.SetToolTip(this.btnGetChapter, "Get Chapters from Inputed Url");
             this.btnGetChapter.UseVisualStyleBackColor = true;
             this.btnGetChapter.Click += new System.EventHandler(this.btnGetChapter_Click);
             // 
@@ -120,7 +115,7 @@
             this.btnAdd.Size = new System.Drawing.Size(62, 33);
             this.btnAdd.TabIndex = 8;
             this.btnAdd.Text = "4";
-            this.toolTip1.SetToolTip(this.btnAdd, "Add selected chapters");
+            this.FormToolTip.SetToolTip(this.btnAdd, "Add selected chapters");
             this.btnAdd.UseVisualStyleBackColor = true;
             this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
             // 
@@ -132,7 +127,7 @@
             this.btnAddAll.Size = new System.Drawing.Size(62, 32);
             this.btnAddAll.TabIndex = 9;
             this.btnAddAll.Text = "8";
-            this.toolTip1.SetToolTip(this.btnAddAll, "Add all chapters");
+            this.FormToolTip.SetToolTip(this.btnAddAll, "Add all chapters");
             this.btnAddAll.UseVisualStyleBackColor = true;
             this.btnAddAll.Click += new System.EventHandler(this.btnAddAll_Click);
             // 
@@ -237,7 +232,7 @@
             this.btnChangeSaveTo.Size = new System.Drawing.Size(30, 23);
             this.btnChangeSaveTo.TabIndex = 13;
             this.btnChangeSaveTo.Text = "...";
-            this.toolTip1.SetToolTip(this.btnChangeSaveTo, "Change Folder");
+            this.FormToolTip.SetToolTip(this.btnChangeSaveTo, "Change Folder");
             this.btnChangeSaveTo.UseVisualStyleBackColor = true;
             this.btnChangeSaveTo.Click += new System.EventHandler(this.btnChangeSaveTo_Click);
             // 
@@ -379,7 +374,7 @@
             this.btnAddBookmark.Size = new System.Drawing.Size(24, 23);
             this.btnAddBookmark.TabIndex = 2;
             this.btnAddBookmark.Text = "B";
-            this.toolTip1.SetToolTip(this.btnAddBookmark, "Bookmark This Url");
+            this.FormToolTip.SetToolTip(this.btnAddBookmark, "Bookmark This Url");
             this.btnAddBookmark.UseVisualStyleBackColor = true;
             this.btnAddBookmark.Click += new System.EventHandler(this.btnAddBookmark_Click);
             // 
@@ -391,7 +386,7 @@
             this.btnRemoveBookmark.Size = new System.Drawing.Size(24, 23);
             this.btnRemoveBookmark.TabIndex = 3;
             this.btnRemoveBookmark.Text = "R";
-            this.toolTip1.SetToolTip(this.btnRemoveBookmark, "Remove This Url From Bookmark");
+            this.FormToolTip.SetToolTip(this.btnRemoveBookmark, "Remove This Url From Bookmark");
             this.btnRemoveBookmark.UseVisualStyleBackColor = true;
             this.btnRemoveBookmark.Click += new System.EventHandler(this.btnRemoveBookmark_Click);
             // 
@@ -403,41 +398,20 @@
             this.checkBoxForPrefix.Size = new System.Drawing.Size(99, 17);
             this.checkBoxForPrefix.TabIndex = 0;
             this.checkBoxForPrefix.Text = "Prefix Counter";
-            this.toolTip1.SetToolTip(this.checkBoxForPrefix, "Add prefix to chapters");
+            this.FormToolTip.SetToolTip(this.checkBoxForPrefix, "Add prefix to chapters");
             this.checkBoxForPrefix.UseVisualStyleBackColor = true;
             this.checkBoxForPrefix.CheckedChanged += new System.EventHandler(this.checkBoxForPrefix_CheckedChanged);
             // 
-            // lbDefaultDestination
+            // cbUseSeriesFolder
             // 
-            this.lbDefaultDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.lbDefaultDestination.AutoSize = true;
-            this.lbDefaultDestination.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbDefaultDestination.Location = new System.Drawing.Point(29, 318);
-            this.lbDefaultDestination.MaximumSize = new System.Drawing.Size(385, 17);
-            this.lbDefaultDestination.MinimumSize = new System.Drawing.Size(64, 17);
-            this.lbDefaultDestination.Name = "lbDefaultDestination";
-            this.lbDefaultDestination.Size = new System.Drawing.Size(118, 17);
-            this.lbDefaultDestination.TabIndex = 34;
-            this.lbDefaultDestination.Text = "Default Destination";
-            this.toolTip1.SetToolTip(this.lbDefaultDestination, "Saves chapters to the default manga folder");
-            this.lbDefaultDestination.UseMnemonic = false;
-            this.lbDefaultDestination.MouseClick += new System.Windows.Forms.MouseEventHandler(this.lbDefaultDestination_MouseClick);
-            // 
-            // lbSeriesDestination
-            // 
-            this.lbSeriesDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.lbSeriesDestination.AutoSize = true;
-            this.lbSeriesDestination.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbSeriesDestination.Location = new System.Drawing.Point(710, 382);
-            this.lbSeriesDestination.MaximumSize = new System.Drawing.Size(380, 17);
-            this.lbSeriesDestination.MinimumSize = new System.Drawing.Size(64, 17);
-            this.lbSeriesDestination.Name = "lbSeriesDestination";
-            this.lbSeriesDestination.Size = new System.Drawing.Size(160, 17);
-            this.lbSeriesDestination.TabIndex = 35;
-            this.lbSeriesDestination.Text = "Series Specific Destination";
-            this.toolTip1.SetToolTip(this.lbSeriesDestination, "Saves chapters to the series\' folder");
-            this.lbSeriesDestination.UseMnemonic = false;
-            this.lbSeriesDestination.MouseClick += new System.Windows.Forms.MouseEventHandler(this.lbSeriesDestination_MouseClick);
+            this.cbUseSeriesFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.cbUseSeriesFolder.AutoSize = true;
+            this.cbUseSeriesFolder.Location = new System.Drawing.Point(116, 17);
+            this.cbUseSeriesFolder.Name = "cbUseSeriesFolder";
+            this.cbUseSeriesFolder.Size = new System.Drawing.Size(131, 17);
+            this.cbUseSeriesFolder.TabIndex = 29;
+            this.cbUseSeriesFolder.Text = "Save in Series Folder";
+            this.cbUseSeriesFolder.UseVisualStyleBackColor = true;
             // 
             // txtMessage
             // 
@@ -459,6 +433,30 @@
             this.groupBox1.TabIndex = 29;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Save As";
+            // 
+            // cbSaveFolder
+            // 
+            this.cbSaveFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.cbSaveFolder.AutoSize = true;
+            this.cbSaveFolder.Checked = true;
+            this.cbSaveFolder.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbSaveFolder.Location = new System.Drawing.Point(25, 17);
+            this.cbSaveFolder.Name = "cbSaveFolder";
+            this.cbSaveFolder.Size = new System.Drawing.Size(59, 17);
+            this.cbSaveFolder.TabIndex = 27;
+            this.cbSaveFolder.Text = "Folder";
+            this.cbSaveFolder.UseVisualStyleBackColor = true;
+            // 
+            // cbSaveCbz
+            // 
+            this.cbSaveCbz.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.cbSaveCbz.AutoSize = true;
+            this.cbSaveCbz.Location = new System.Drawing.Point(90, 17);
+            this.cbSaveCbz.Name = "cbSaveCbz";
+            this.cbSaveCbz.Size = new System.Drawing.Size(46, 17);
+            this.cbSaveCbz.TabIndex = 28;
+            this.cbSaveCbz.Text = "CBZ";
+            this.cbSaveCbz.UseVisualStyleBackColor = true;
             // 
             // groupBox2
             // 
@@ -538,28 +536,6 @@
             this.aboutToolStripMenuItem.Text = "About";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
-            // rdDefaultDestination
-            // 
-            this.rdDefaultDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.rdDefaultDestination.AutoSize = true;
-            this.rdDefaultDestination.Checked = true;
-            this.rdDefaultDestination.Location = new System.Drawing.Point(690, 353);
-            this.rdDefaultDestination.Name = "rdDefaultDestination";
-            this.rdDefaultDestination.Size = new System.Drawing.Size(14, 13);
-            this.rdDefaultDestination.TabIndex = 32;
-            this.rdDefaultDestination.TabStop = true;
-            this.rdDefaultDestination.UseVisualStyleBackColor = true;
-            // 
-            // rdSeriesDestination
-            // 
-            this.rdSeriesDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.rdSeriesDestination.AutoSize = true;
-            this.rdSeriesDestination.Location = new System.Drawing.Point(690, 385);
-            this.rdSeriesDestination.Name = "rdSeriesDestination";
-            this.rdSeriesDestination.Size = new System.Drawing.Size(14, 13);
-            this.rdSeriesDestination.TabIndex = 33;
-            this.rdSeriesDestination.UseVisualStyleBackColor = true;
-            // 
             // lbDestination
             // 
             this.lbDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
@@ -571,76 +547,22 @@
             this.lbDestination.TabIndex = 26;
             this.lbDestination.Text = "Save Destination";
             // 
-            // cbUseSeriesFolder
+            // txtSaveTo
             // 
-            this.cbUseSeriesFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.cbUseSeriesFolder.AutoSize = true;
-            this.cbUseSeriesFolder.Location = new System.Drawing.Point(116, 17);
-            this.cbUseSeriesFolder.Name = "cbUseSeriesFolder";
-            this.cbUseSeriesFolder.Size = new System.Drawing.Size(131, 17);
-            this.cbUseSeriesFolder.TabIndex = 29;
-            this.cbUseSeriesFolder.Text = "Save in Series Folder";
-            this.toolTip1.SetToolTip(this.cbUseSeriesFolder, "Save chapters in \'D:\\Manga\\Detective Conan\'");
-            this.cbUseSeriesFolder.UseVisualStyleBackColor = true;
-            // 
-            // rbSaveFolder
-            // 
-            this.rbSaveFolder.AutoSize = true;
-            this.rbSaveFolder.Checked = true;
-            this.rbSaveFolder.Location = new System.Drawing.Point(692, 319);
-            this.rbSaveFolder.Name = "rbSaveFolder";
-            this.rbSaveFolder.Size = new System.Drawing.Size(58, 17);
-            this.rbSaveFolder.TabIndex = 36;
-            this.rbSaveFolder.TabStop = true;
-            this.rbSaveFolder.Text = "Folder";
-            this.rbSaveFolder.UseVisualStyleBackColor = true;
-            // 
-            // rbSaveCbz
-            // 
-            this.rbSaveCbz.AutoSize = true;
-            this.rbSaveCbz.Location = new System.Drawing.Point(756, 318);
-            this.rbSaveCbz.Name = "rbSaveCbz";
-            this.rbSaveCbz.Size = new System.Drawing.Size(45, 17);
-            this.rbSaveCbz.TabIndex = 37;
-            this.rbSaveCbz.Text = "CBZ";
-            this.rbSaveCbz.UseVisualStyleBackColor = true;
-            // 
-            // cbSaveCbz
-            // 
-            this.cbSaveCbz.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.cbSaveCbz.AutoSize = true;
-            this.cbSaveCbz.Location = new System.Drawing.Point(90, 17);
-            this.cbSaveCbz.Name = "cbSaveCbz";
-            this.cbSaveCbz.Size = new System.Drawing.Size(46, 17);
-            this.cbSaveCbz.TabIndex = 28;
-            this.cbSaveCbz.Text = "CBZ";
-            this.cbSaveCbz.UseVisualStyleBackColor = true;
-            // 
-            // cbSaveFolder
-            // 
-            this.cbSaveFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.cbSaveFolder.AutoSize = true;
-            this.cbSaveFolder.Checked = true;
-            this.cbSaveFolder.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.cbSaveFolder.Location = new System.Drawing.Point(25, 17);
-            this.cbSaveFolder.Name = "cbSaveFolder";
-            this.cbSaveFolder.Size = new System.Drawing.Size(59, 17);
-            this.cbSaveFolder.TabIndex = 27;
-            this.cbSaveFolder.Text = "Folder";
-            this.cbSaveFolder.UseVisualStyleBackColor = true;
+            this.txtSaveTo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtSaveTo.Location = new System.Drawing.Point(21, 319);
+            this.txtSaveTo.Name = "txtSaveTo";
+            this.txtSaveTo.Size = new System.Drawing.Size(405, 22);
+            this.txtSaveTo.TabIndex = 35;
+            this.txtSaveTo.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.txtSaveTo_KeyPress);
             // 
             // FormMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1004, 606);
-            this.Controls.Add(this.rbSaveCbz);
-            this.Controls.Add(this.lbSeriesDestination);
-            this.Controls.Add(this.rbSaveFolder);
-            this.Controls.Add(this.lbDefaultDestination);
             this.Controls.Add(this.lbDestination);
-            this.Controls.Add(this.rdSeriesDestination);
-            this.Controls.Add(this.rdDefaultDestination);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.txtMessage);
@@ -662,6 +584,7 @@
             this.Controls.Add(this.dgvQueueChapter);
             this.Controls.Add(this.menuStrip1);
             this.Controls.Add(this.dgvChapter);
+            this.Controls.Add(this.txtSaveTo);
             this.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip1;
@@ -708,7 +631,7 @@
         private System.Windows.Forms.ComboBox cbTitleUrl;
         private System.Windows.Forms.Button btnAddBookmark;
         private System.Windows.Forms.Button btnRemoveBookmark;
-        private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.ToolTip FormToolTip;
         private System.Windows.Forms.TextBox txtMessage;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColChapterName;
         private System.Windows.Forms.DataGridViewTextBoxColumn ColChapterStatus;
@@ -725,15 +648,10 @@
         private System.Windows.Forms.ToolStripMenuItem wikiToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem bugReportToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
-        private System.Windows.Forms.RadioButton rdDefaultDestination;
-        private System.Windows.Forms.RadioButton rdSeriesDestination;
         private System.Windows.Forms.Label lbDestination;
-        private System.Windows.Forms.Label lbDefaultDestination;
-        private System.Windows.Forms.Label lbSeriesDestination;
         private System.Windows.Forms.CheckBox cbUseSeriesFolder;
-        private System.Windows.Forms.RadioButton rbSaveCbz;
-        private System.Windows.Forms.RadioButton rbSaveFolder;
         private System.Windows.Forms.CheckBox cbSaveCbz;
         private System.Windows.Forms.CheckBox cbSaveFolder;
+        private System.Windows.Forms.TextBox txtSaveTo;
     }
 }

--- a/MangaRipper/Forms/FormMain.Designer.cs
+++ b/MangaRipper/Forms/FormMain.Designer.cs
@@ -418,6 +418,7 @@
             this.lbDefaultDestination.Text = "Default Destination";
             this.toolTip1.SetToolTip(this.lbDefaultDestination, "Saves the chapter to the default manga folder");
             this.lbDefaultDestination.UseMnemonic = false;
+            this.lbDefaultDestination.MouseClick += new System.Windows.Forms.MouseEventHandler(this.lbDefaultDestination_MouseClick);
             // 
             // lbSeriesDestination
             // 
@@ -433,6 +434,7 @@
             this.lbSeriesDestination.Text = "Series Specific Destination";
             this.toolTip1.SetToolTip(this.lbSeriesDestination, "Saves the chapter to the series\' folder");
             this.lbSeriesDestination.UseMnemonic = false;
+            this.lbSeriesDestination.MouseClick += new System.Windows.Forms.MouseEventHandler(this.lbSeriesDestination_MouseClick);
             // 
             // txtMessage
             // 

--- a/MangaRipper/Forms/FormMain.Designer.cs
+++ b/MangaRipper/Forms/FormMain.Designer.cs
@@ -409,14 +409,14 @@
             this.lbDefaultDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.lbDefaultDestination.AutoSize = true;
             this.lbDefaultDestination.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbDefaultDestination.Location = new System.Drawing.Point(55, 323);
+            this.lbDefaultDestination.Location = new System.Drawing.Point(55, 319);
             this.lbDefaultDestination.MaximumSize = new System.Drawing.Size(385, 17);
-            this.lbDefaultDestination.MinimumSize = new System.Drawing.Size(380, 17);
+            this.lbDefaultDestination.MinimumSize = new System.Drawing.Size(64, 17);
             this.lbDefaultDestination.Name = "lbDefaultDestination";
-            this.lbDefaultDestination.Size = new System.Drawing.Size(380, 17);
+            this.lbDefaultDestination.Size = new System.Drawing.Size(118, 17);
             this.lbDefaultDestination.TabIndex = 34;
             this.lbDefaultDestination.Text = "Default Destination";
-            this.toolTip1.SetToolTip(this.lbDefaultDestination, "Saves the chapter to the default manga folder");
+            this.toolTip1.SetToolTip(this.lbDefaultDestination, "Saves chapters to the default manga folder");
             this.lbDefaultDestination.UseMnemonic = false;
             this.lbDefaultDestination.MouseClick += new System.Windows.Forms.MouseEventHandler(this.lbDefaultDestination_MouseClick);
             // 
@@ -425,14 +425,14 @@
             this.lbSeriesDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.lbSeriesDestination.AutoSize = true;
             this.lbSeriesDestination.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbSeriesDestination.Location = new System.Drawing.Point(55, 358);
+            this.lbSeriesDestination.Location = new System.Drawing.Point(55, 354);
             this.lbSeriesDestination.MaximumSize = new System.Drawing.Size(380, 17);
-            this.lbSeriesDestination.MinimumSize = new System.Drawing.Size(380, 17);
+            this.lbSeriesDestination.MinimumSize = new System.Drawing.Size(64, 17);
             this.lbSeriesDestination.Name = "lbSeriesDestination";
-            this.lbSeriesDestination.Size = new System.Drawing.Size(380, 17);
+            this.lbSeriesDestination.Size = new System.Drawing.Size(160, 17);
             this.lbSeriesDestination.TabIndex = 35;
             this.lbSeriesDestination.Text = "Series Specific Destination";
-            this.toolTip1.SetToolTip(this.lbSeriesDestination, "Saves the chapter to the series\' folder");
+            this.toolTip1.SetToolTip(this.lbSeriesDestination, "Saves chapters to the series\' folder");
             this.lbSeriesDestination.UseMnemonic = false;
             this.lbSeriesDestination.MouseClick += new System.Windows.Forms.MouseEventHandler(this.lbSeriesDestination_MouseClick);
             // 
@@ -474,7 +474,7 @@
             this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.groupBox1.Controls.Add(this.cbSaveFolder);
             this.groupBox1.Controls.Add(this.cbSaveCbz);
-            this.groupBox1.Location = new System.Drawing.Point(12, 401);
+            this.groupBox1.Location = new System.Drawing.Point(102, 397);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(118, 41);
             this.groupBox1.TabIndex = 29;
@@ -485,7 +485,7 @@
             // 
             this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.groupBox2.Controls.Add(this.checkBoxForPrefix);
-            this.groupBox2.Location = new System.Drawing.Point(136, 401);
+            this.groupBox2.Location = new System.Drawing.Point(226, 397);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Size = new System.Drawing.Size(120, 41);
             this.groupBox2.TabIndex = 30;
@@ -563,7 +563,7 @@
             this.rdDefaultDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.rdDefaultDestination.AutoSize = true;
             this.rdDefaultDestination.Checked = true;
-            this.rdDefaultDestination.Location = new System.Drawing.Point(35, 326);
+            this.rdDefaultDestination.Location = new System.Drawing.Point(35, 322);
             this.rdDefaultDestination.Name = "rdDefaultDestination";
             this.rdDefaultDestination.Size = new System.Drawing.Size(14, 13);
             this.rdDefaultDestination.TabIndex = 32;
@@ -574,7 +574,7 @@
             // 
             this.rdSeriesDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.rdSeriesDestination.AutoSize = true;
-            this.rdSeriesDestination.Location = new System.Drawing.Point(35, 361);
+            this.rdSeriesDestination.Location = new System.Drawing.Point(35, 357);
             this.rdSeriesDestination.Name = "rdSeriesDestination";
             this.rdSeriesDestination.Size = new System.Drawing.Size(14, 13);
             this.rdSeriesDestination.TabIndex = 33;
@@ -585,7 +585,7 @@
             this.lbDestination.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.lbDestination.AutoSize = true;
             this.lbDestination.Font = new System.Drawing.Font("Segoe UI Semibold", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbDestination.Location = new System.Drawing.Point(11, 291);
+            this.lbDestination.Location = new System.Drawing.Point(11, 288);
             this.lbDestination.Name = "lbDestination";
             this.lbDestination.Size = new System.Drawing.Size(123, 20);
             this.lbDestination.TabIndex = 26;
@@ -629,6 +629,7 @@
             this.Name = "FormMain";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.FormMain_FormClosing);
             this.Load += new System.EventHandler(this.FormMain_Load);
+            this.Paint += new System.Windows.Forms.PaintEventHandler(this.FormMain_Paint);
             ((System.ComponentModel.ISupportInitialize)(this.dgvQueueChapter)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgvSupportedSites)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.dgvChapter)).EndInit();

--- a/MangaRipper/Forms/FormMain.cs
+++ b/MangaRipper/Forms/FormMain.cs
@@ -309,12 +309,13 @@ namespace MangaRipper.Forms
 
         private void FormMain_Paint(object sender, PaintEventArgs e)
         {
-            // Draw line separating the save destination and the options.
+            // Draw line separating the save destinations and the options.
 
-            int offSetX = Convert.ToInt32(dgvChapter.Width * 0.125);
+            int offSetX = Convert.ToInt32(dgvChapter.Width * 0.125),
+                y = rdSeriesDestination.Bottom + 15;
 
-            Point startingPoint = new Point(dgvChapter.Left + offSetX, rdSeriesDestination.Bottom + 15),
-                  endingPoint = new Point(dgvChapter.Right - offSetX, rdSeriesDestination.Bottom + 15);
+            Point startingPoint = new Point(dgvChapter.Left + offSetX, y),
+                  endingPoint = new Point(dgvChapter.Right - offSetX, y);
 
             e.Graphics.DrawLine(Pens.Gainsboro, startingPoint, endingPoint);
 
@@ -450,7 +451,7 @@ namespace MangaRipper.Forms
 
             var item = (Chapter)dgvChapter.Rows[0].DataBoundItem;
             series = item.Name.Substring(0, item.Name.LastIndexOf(" ")).Trim();
-            seriesPath = Path.Combine(baseSeriesDestination, series);
+            seriesPath = Core.Extensions.ExtensionHelper.RemoveFileNameInvalidChar(Path.Combine(baseSeriesDestination, series));
             
             lbSeriesDestination.Text = seriesPath;
 

--- a/MangaRipper/Forms/FormMain.cs
+++ b/MangaRipper/Forms/FormMain.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -304,6 +305,19 @@ namespace MangaRipper.Forms
             appConfig.PrefixChecked = checkBoxForPrefix.Checked;
             _appConf.SaveCommonSettings(appConfig);
             _appConf.SaveDownloadChapterTasks(_downloadQueue);
+        }
+
+        private void FormMain_Paint(object sender, PaintEventArgs e)
+        {
+            // Draw line separating the save destination and the options.
+
+            int offSetX = Convert.ToInt32(dgvChapter.Width * 0.125);
+
+            Point startingPoint = new Point(dgvChapter.Left + offSetX, rdSeriesDestination.Bottom + 15),
+                  endingPoint = new Point(dgvChapter.Right - offSetX, rdSeriesDestination.Bottom + 15);
+
+            e.Graphics.DrawLine(Pens.Gainsboro, startingPoint, endingPoint);
+
         }
 
         private void LoadBookmark()

--- a/MangaRipper/Forms/FormMain.cs
+++ b/MangaRipper/Forms/FormMain.cs
@@ -27,18 +27,24 @@ namespace MangaRipper.Forms
             get
             {
                 if (rdSeriesDestination.Checked)
+                {
                     return lbSeriesDestination.Text;
-
+                }
                 else
+                {
                     return lbDefaultDestination.Text;
+                }
             }
             set
             {
                 if (rdSeriesDestination.Checked)
+                {
                     lbSeriesDestination.Text = value;
-
+                }
                 else
+                {
                     lbDefaultDestination.Text = value;
+                }
             }
         }
 
@@ -174,10 +180,13 @@ namespace MangaRipper.Forms
         private IEnumerable<OutputFormat> GetOutputFormats()
         {
             var outputFormats = new List<OutputFormat>();
+
             if (cbSaveFolder.Checked)
                 outputFormats.Add(OutputFormat.Folder);
+
             if (cbSaveCbz.Checked)
                 outputFormats.Add(OutputFormat.CBZ);
+
             return outputFormats;
         }
 
@@ -403,7 +412,7 @@ namespace MangaRipper.Forms
         {
             Process.Start("https://github.com/NguyenDanPhuong/MangaRipper/wiki/Bug-Report");
         }
-               
+
         /// <summary>
         /// Formulates a save destination based on the current series and selects it at the current series' save destination if it already exists.
         /// </summary>
@@ -411,18 +420,18 @@ namespace MangaRipper.Forms
         {
             if (dgvChapter.RowCount == 0)
                 return;
-            
-            // Cost to make it class-level?
+
+            // TODO Cost to make it class-level?
             var state = _appConf.LoadCommonSettings();
-            
+
             string
                 baseSeriesDestination = state.BaseSeriesDestination,
-                series = string.Empty,
-                seriesPath = string.Empty;
+                series,
+                seriesPath;
 
             if (!string.IsNullOrWhiteSpace(cbTitleUrl.Text))
             {
-                Uri seriesUri = null;
+                Uri seriesUri;
 
                 if (Uri.TryCreate(cbTitleUrl.Text, UriKind.Absolute, out seriesUri))
                     series = seriesUri.ToString();
@@ -438,7 +447,7 @@ namespace MangaRipper.Forms
 
             if (string.IsNullOrWhiteSpace(series))
             {
-                // Todo: Set series-specific directory path to the default value.
+                // TODO Set series-specific directory path to the default value.
                 return;
             }
 
@@ -446,13 +455,12 @@ namespace MangaRipper.Forms
             if (string.IsNullOrEmpty(baseSeriesDestination))
                 baseSeriesDestination = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
 
-            series = series.TrimEnd('/');
-            series = series.Substring(series.LastIndexOf('/') + 1);
+            series = series.TrimEnd('/').Substring(series.LastIndexOf('/') + 1);
 
             var item = (Chapter)dgvChapter.Rows[0].DataBoundItem;
             series = Core.Extensions.ExtensionHelper.RemoveFileNameInvalidChar(item.Name.Substring(0, item.Name.LastIndexOf(" ")).Trim());
             seriesPath = Path.Combine(baseSeriesDestination, series);
-            
+
             lbSeriesDestination.Text = seriesPath;
 
             /* 
@@ -461,11 +469,13 @@ namespace MangaRipper.Forms
              * For the user's convenience, an option could allow saving to the series directory to be opt-out instead of opt-in.
              * Automatically putting each in its own directory could be troublesome for users who read a lot of one-shot manga.
             */
-            if (Directory.Exists(seriesPath))
+            if (Directory.Exists(seriesPath)) {
                 rdSeriesDestination.Checked = true;
-
+            }
             else
+            {
                 rdDefaultDestination.Checked = true;
+            }
 
         }
 

--- a/MangaRipper/Forms/FormMain.cs
+++ b/MangaRipper/Forms/FormMain.cs
@@ -450,8 +450,8 @@ namespace MangaRipper.Forms
             series = series.Substring(series.LastIndexOf('/') + 1);
 
             var item = (Chapter)dgvChapter.Rows[0].DataBoundItem;
-            series = item.Name.Substring(0, item.Name.LastIndexOf(" ")).Trim();
-            seriesPath = Core.Extensions.ExtensionHelper.RemoveFileNameInvalidChar(Path.Combine(baseSeriesDestination, series));
+            series = Core.Extensions.ExtensionHelper.RemoveFileNameInvalidChar(item.Name.Substring(0, item.Name.LastIndexOf(" ")).Trim());
+            seriesPath = Path.Combine(baseSeriesDestination, series);
             
             lbSeriesDestination.Text = seriesPath;
 

--- a/MangaRipper/Forms/FormMain.cs
+++ b/MangaRipper/Forms/FormMain.cs
@@ -45,6 +45,13 @@ namespace MangaRipper.Forms
         {
             try
             {
+                if (!System.Net.NetworkInformation.NetworkInterface.GetIsNetworkAvailable())
+                {
+                    MessageBox.Show("An Internet connection has not been detected.", Application.ProductName,  MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    Logger.Error("Aborting chapter retrieval, no Internet connection.");
+                    return;
+                }
+
                 btnGetChapter.Enabled = false;
                 var titleUrl = cbTitleUrl.Text;
 
@@ -108,6 +115,7 @@ namespace MangaRipper.Forms
             foreach (DataGridViewRow item in dgvQueueChapter.SelectedRows)
             {
                 var chapter = (DownloadChapterTask)item.DataBoundItem;
+
                 if (chapter.IsBusy == false)
                     _downloadQueue.Remove(chapter);
             }
@@ -278,8 +286,7 @@ namespace MangaRipper.Forms
                 }
             }
         }
-
-
+        
         private void FormMain_FormClosing(object sender, FormClosingEventArgs e)
         {
             var appConfig = _appConf.LoadCommonSettings();
@@ -346,7 +353,14 @@ namespace MangaRipper.Forms
             // Reject the user's keystroke if it's an invalid character for paths.
             if ((Keys)e.KeyChar != Keys.Back && Path.GetInvalidPathChars().Contains(e.KeyChar))
             {
+                // Display a tooltip telling the user their input has been rejected.
+                FormToolTip.Show($"The character \"{e.KeyChar}\" is a invalid for use in paths.", txtSaveTo);
+
                 e.Handled = true;
+            }
+            else
+            {
+                FormToolTip.SetToolTip(txtSaveTo, string.Empty);
             }
         }
 
@@ -399,8 +413,7 @@ namespace MangaRipper.Forms
         {
             if (dgvChapter.RowCount == 0)
                 return;
-
-            // TODO Cost to make it class-level?
+            
             var state = _appConf.LoadCommonSettings();
 
             string

--- a/MangaRipper/Forms/FormMain.resx
+++ b/MangaRipper/Forms/FormMain.resx
@@ -117,8 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>248, 17</value>
+  <metadata name="FormToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
   <metadata name="ColChapterName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -142,10 +142,10 @@
     <value>True</value>
   </metadata>
   <metadata name="saveDestinationDirectoryBrowser.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>137, 17</value>
   </metadata>
   <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>345, 17</value>
+    <value>368, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>63</value>

--- a/MangaRipper/Forms/FormMain.resx
+++ b/MangaRipper/Forms/FormMain.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>302, 17</value>
+    <value>248, 17</value>
   </metadata>
   <metadata name="ColChapterName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -141,11 +141,14 @@
   <metadata name="dataGridViewTextBoxColumn4.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="folderBrowserDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="saveDestinationDirectoryBrowser.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>399, 17</value>
+    <value>345, 17</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>25</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/MangaRipper/Forms/FormMain.resx
+++ b/MangaRipper/Forms/FormMain.resx
@@ -148,7 +148,7 @@
     <value>345, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>25</value>
+    <value>63</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/MangaRipper/Helpers/ApplicationConfiguration.cs
+++ b/MangaRipper/Helpers/ApplicationConfiguration.cs
@@ -71,7 +71,7 @@ namespace MangaRipper.Helpers
                 throw new ArgumentNullException(nameof(objectToStore));
             }
 
-            Logger.Info("> SaveObject(): " + fileName);
+            Logger.Info("> SaveObject(): " + Core.Extensions.ExtensionHelper.SanitizeUserName(fileName));
             var serializer = new JsonSerializer();
             using (var sw = new StreamWriter(fileName))
             using (JsonWriter writer = new JsonTextWriter(sw))
@@ -90,7 +90,7 @@ namespace MangaRipper.Helpers
             var result = default(T);
             try
             {
-                Logger.Info("> LoadObject(): " + fileName);
+                Logger.Info("> LoadObject(): " + Core.Extensions.ExtensionHelper.SanitizeUserName(fileName));
 
                 var serializer = new JsonSerializer();
 

--- a/MangaRipper/Helpers/CommonSettings.cs
+++ b/MangaRipper/Helpers/CommonSettings.cs
@@ -12,5 +12,10 @@ namespace MangaRipper.Helpers
         public FormWindowState WindowState { get; set; }
         public bool CbzChecked { get; set; }
         public bool PrefixChecked { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base portion of the series-specific directory.
+        /// </summary>
+        public string BaseSeriesDestination { get; set; }
     }
 }

--- a/MangaRipper/MangaRipper.Configuration.json
+++ b/MangaRipper/MangaRipper.Configuration.json
@@ -2,5 +2,5 @@
   "Plugin.Batoto.Username": "gufrohepra",
   "Plugin.Batoto.Password": "123",
   "Plugin.KissManga.IV": "a5e8e2e9c2721be0a84ad660c472c1f3",
-  "Plugin.KissManga.Chko": "72nnasdasd9asdn123"
+  "Plugin.KissManga.Chko": "nsfd732nsdnds823nsdf"
 }


### PR DESCRIPTION
A rough implementation of the feature mentioned in Issue #58. Emphasis has been placed on backwards compatibility with the original save destination. The user is given two save options, one for the original save directory and another for a directory specific to the series.

![capture](https://cloud.githubusercontent.com/assets/6389344/24517036/0a24a56a-157d-11e7-8503-5d6672604e1f.PNG)

Details on how it works:
The original 'SaveTo' location exists in the top option, while the series at the bottom. When the user clicks 'Get Chapters', the series' name is returned once the chapters are listed. Using the 'BaseSeriesDestination' property with the series name, the series-specific path is created. The base series destination exists separately from the 'SaveTo' property and may be specified to save anywhere.

The chapter(s) will be downloaded to the directory corresponding to which RadioButton is checked. If the series-specific directory already exists, its RadioButton will be checked automatically.


As it's a rough implementation, there is room for improvement or it may be scrapped entirely.
