### PR TITLE
[Do not merge yet] Add Alternative Links logic, and test it on MangaStream.

### DIFF
--- a/MangaRipper.Core/Interfaces/IMangaService.cs
+++ b/MangaRipper.Core/Interfaces/IMangaService.cs
@@ -27,6 +27,23 @@ namespace MangaRipper.Core.Interfaces
         bool Of(string link);
 
         /// <summary>
+        /// Override method for Test purpose
+        /// </summary>
+        /// <param name="link"></param>
+        /// <param name="providerUrl"></param>
+        /// <returns></returns>
+        bool Of(string link, string providerUrl);
+
+        /// <summary>
+        /// Check also alternative WebSite links
+        /// Done in case if website was moved, or only mirror is available
+        /// </summary>
+        /// <param name="link">Uri from "Of" method</param>
+        /// <param name="address">Address of MangaProvider</param>
+        /// <returns>Correct link</returns>
+        string CheckWithAlternative(Uri link, string address);
+
+        /// <summary>
         /// Find all chapters inside a manga
         /// </summary>
         /// <param name="manga"></param>

--- a/MangaRipper.Core/Interfaces/MangaService.cs
+++ b/MangaRipper.Core/Interfaces/MangaService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MangaRipper.Core.Models;
@@ -13,14 +12,49 @@ namespace MangaRipper.Core.Interfaces
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
+        private string[] AlternativeLinks;
+
         public virtual void Configuration(IEnumerable<KeyValuePair<string, object>> settings)
         {
-            Logger.Info("The plugin has no configuration");
+            if (settings.Any())
+            {
+                var settingCollection = settings.ToArray();
+                if (settingCollection.Any(i => i.Key.Equals("AlternativeLinks")))
+                {
+                    AlternativeLinks = settingCollection.First(i => i.Key.Equals("AlternativeLinks")).Value.ToString().Split(',');
+                }
+            }
+            else
+            {
+                Logger.Info("The plugin has no configuration");
+            }
+        }
+        
+        public abstract SiteInformation GetInformation();
+        
+        public abstract bool Of(string link);
+        
+        public virtual bool Of(string link, string providerUrl)
+        {
+            return Of(link);
         }
 
-        public abstract SiteInformation GetInformation();
+        public string CheckWithAlternative(Uri link, string address)
+        {
+            // Original Address is the right one
+            if (link.Host.Equals(address))
+            {
+                return address;
+            }
+            
+            // Check Alternate links
+            if (AlternativeLinks != null && Array.IndexOf(AlternativeLinks, link.Host) > -1)
+            {
+                return AlternativeLinks[Array.IndexOf(AlternativeLinks, link.Host)];
+            }
 
-        public abstract bool Of(string link);
+            return null;
+        }
 
         public abstract Task<IEnumerable<Chapter>> FindChapters(string manga, IProgress<int> progress,
             CancellationToken cancellationToken);

--- a/MangaRipper.Plugin.KissManga/KissManga.cs
+++ b/MangaRipper.Plugin.KissManga/KissManga.cs
@@ -40,6 +40,8 @@ namespace MangaRipper.Plugin.KissManga
 
         public override void Configuration(IEnumerable<KeyValuePair<string, object>> settings)
         {
+            base.Configuration(settings);
+
             var settingCollection = settings.ToArray();
             if (settingCollection.Any(i => i.Key.Equals("IV")))
             {

--- a/MangaRipper/MangaRipper.Configuration.json
+++ b/MangaRipper/MangaRipper.Configuration.json
@@ -3,5 +3,6 @@
   "Plugin.Batoto.Password": "password",
   "Plugin.Batoto.Languages": "",
   "Plugin.KissManga.IV": "a5e8e2e9c2721be0a84ad660c472c1f3",
-  "Plugin.KissManga.Chko": "nsfd732nsdnds823nsdf"
+  "Plugin.KissManga.Chko": "nsfd732nsdnds823nsdf",
+  "Plugin.ServiceName.AlternativeLinks": "testurl.com"
 }


### PR DESCRIPTION
@NguyenDanPhuong  @JedBurke could you please take a look at this Pull Request.
I thinking of implementing alternative Url logic, which allows users easily change the address of the server if it will be moved, or mirror address will pop up.
All they need to do is to put the link(s) into the configuration. For example, for  Mangafox it will be something like "Plugin.MangaFox.AlternativeLinks": "mangafox.mirror.com".
The configuration will be taken during plugin initialization, and if the method is overridden, all you need to do is to call "base.Configuration(settings);".
What do you think?
#104