### PR TITLE
Added image url validation filter to ReadOPM plugin

### DIFF
--- a/MangaRipper.Plugin.ReadOPM/ReadOPM.cs
+++ b/MangaRipper.Plugin.ReadOPM/ReadOPM.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,7 +10,7 @@ using MangaRipper.Core.Models;
 namespace MangaRipper.Plugin.ReadOPM
 {
     /// <summary>
-    /// Support find chapters, images from MangaStream
+    /// Support find chapters, images from readopm
     /// </summary>
     public class ReadOPM : IMangaService
     {
@@ -54,7 +55,14 @@ namespace MangaRipper.Plugin.ReadOPM
             // find all pages in a chapter
             string input = await downloader.DownloadStringAsync(chapter.Url, cancellationToken);
             var images = selector.SelectMany(input, "//div[contains(@class,'img_container')]/img")
-                .Select(n => n.Attributes["src"]);
+                .Select(n => n.Attributes["src"])
+                .Where(src =>
+                {
+                    Uri validatedUri;
+                    return !string.IsNullOrWhiteSpace(src)
+                    && Uri.TryCreate(src, UriKind.Absolute, out validatedUri)
+                    && !string.IsNullOrWhiteSpace(Path.GetFileName(validatedUri.LocalPath));
+                });
 
             return images;
         }


### PR DESCRIPTION
This makes downloading chapters with some bad image urls possible because otherwise MR throws an exception. Perhaps image urls should be checked on the side of MangaRipper as the plugin's job is primarily to collect image links it finds inside the chapter page. In my case those image urls were wrapped just like a real chapter image (same div class) and the website also shows empty boxes in their place which means its an error made by whoever set up that chapter page.
Example of bad url: 
https://2.bp.blogspot.com/-ACa9a8ivc-Y/WJCtIBRhz9I/AAAAAAAAD7g/TYP8XliGYrc_GZBDJEJ5H7iwXDh2VfADwCLcB/s1600/%255Breadopm.com%255D71_021.png\\
Note the slashes at the end.
