### PR TITLE
Reuse the CloudFlare Cookies with singleton help

### DIFF
--- a/MangaRipper.Core/MangaRipper.Core.csproj
+++ b/MangaRipper.Core/MangaRipper.Core.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Outputers\IOutputer.cs" />
     <Compile Include="Outputers\IOutputFactory.cs" />
     <Compile Include="Outputers\OutputFactory.cs" />
+    <Compile Include="Providers\CacheProvider.cs" />
     <Compile Include="Renaming\FileManiuplation.cs" />
     <Compile Include="Renaming\IFileManipulation.cs" />
     <Compile Include="Renaming\IRenamer.cs" />

--- a/MangaRipper.Core/Providers/CacheProvider.cs
+++ b/MangaRipper.Core/Providers/CacheProvider.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace MangaRipper.Core.Providers
+{
+    /// <summary>
+    /// Our Singleton to keep the cookies (For now it's only CloudFlare cookies)
+    /// </summary>
+    public sealed class CacheProvider
+    {
+        private static readonly Lazy<CacheProvider> lazy =
+        new Lazy<CacheProvider>(() => new CacheProvider());
+
+        public static CacheProvider Instance { get { return lazy.Value; } }
+
+        private Dictionary<string, Cookie> Cache;
+
+        private CacheProvider()
+        {
+            Cache = new Dictionary<string, Cookie>();
+        }
+
+        public bool CacheExists(string key)
+        {
+            return Cache.ContainsKey(key);
+        }
+
+        public Cookie GetCacheValue(string key)
+        {
+            if (CacheExists(key))
+            {
+                return Cache[key];
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        public void SetCacheValue(string key, Cookie value)
+        {
+            Cache[key] = value;
+        }
+
+    }
+}

--- a/MangaRipper.Core/Services/Downloader.cs
+++ b/MangaRipper.Core/Services/Downloader.cs
@@ -63,7 +63,7 @@ namespace MangaRipper.Core.Interfaces
         {
             var cookieContainer = new CookieContainer();
             // Set CloudFlare cookies if we have one
-            if (CacheProvider.Instance.CacheExists("__cfduid"))
+            if (CacheProvider.Instance.CacheExists("__cfduid") && CacheProvider.Instance.CacheExists("cf_clearance"))
             {
                 cookieContainer.Add(CacheProvider.Instance.GetCacheValue("__cfduid"));
                 cookieContainer.Add(CacheProvider.Instance.GetCacheValue("cf_clearance"));

--- a/MangaRipper.Core/Services/Downloader.cs
+++ b/MangaRipper.Core/Services/Downloader.cs
@@ -1,7 +1,9 @@
 ﻿using CloudFlareUtilities;
 using MangaRipper.Core.FilenameDetectors;
-using System;
+using MangaRipper.Core.Providers;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -36,6 +38,7 @@ namespace MangaRipper.Core.Interfaces
             var request = CreateRequest();
             using (var response = await request.GetAsync(url, cancellationToken))
             {
+                GetAllCloudFlareCookies(response);
                 var filename = filenameDetector.GetFilename(url, response.Content.Headers);
                 var fileNameWithPath = Path.Combine(folder, filename);
                 using (var streamReader = new FileStream(fileNameWithPath, FileMode.Create, FileAccess.Write))
@@ -51,23 +54,60 @@ namespace MangaRipper.Core.Interfaces
             var request = CreateRequest();
             using (var response = await request.GetAsync(url, cancellationToken))
             {
+                GetAllCloudFlareCookies(response);
                 return await response.Content.ReadAsStringAsync();
             }
         }
 
         private HttpClient CreateRequest()
         {
+            var cookieContainer = new CookieContainer();
+            // Set CloudFlare cookies if we have one
+            if (CacheProvider.Instance.CacheExists("__cfduid"))
+            {
+                cookieContainer.Add(CacheProvider.Instance.GetCacheValue("__cfduid"));
+                cookieContainer.Add(CacheProvider.Instance.GetCacheValue("cf_clearance"));
+            }
+
             var firstHandle = new HttpClientHandler
             {
                 AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip,
                 Credentials = CredentialCache.DefaultCredentials,
                 AllowAutoRedirect = false,
-                CookieContainer = new CookieContainer()
+                CookieContainer = cookieContainer
             };
 
             var cloudFlareHandler = new ClearanceHandler(firstHandle);
             var request = new HttpClient(cloudFlareHandler);
             return request;
+        }
+
+        /// <summary>
+        /// Get cookies which allow us to pass the CloudFlare calculation on next request
+        /// </summary>
+        /// <param name="response">Take the domain and cookies from it</param>
+        private void GetAllCloudFlareCookies(HttpResponseMessage response)
+        {
+            List<string> cookies = response.Headers
+                .Where(pair => pair.Key == "Set-Cookie")
+                .SelectMany(pair => pair.Value)
+                .ToList();
+
+            foreach (var cookie in cookies)
+            {
+                if (cookie.Contains("__cfduid") || cookie.Contains("cf_clearance"))
+                {
+                    var splitNum = cookie.IndexOf('=');
+                    var key = cookie.Substring(0, splitNum);
+                    var domain = response.RequestMessage.RequestUri;
+                    var value = new Cookie(key, cookie.Substring(splitNum + 1))
+                    {
+                        Domain = domain.Host
+                    };
+
+                    CacheProvider.Instance.SetCacheValue(key, value);
+                }
+            }
         }
     }
 }

--- a/MangaRipper.Test/Plugin.cs
+++ b/MangaRipper.Test/Plugin.cs
@@ -148,9 +148,9 @@ namespace MangaRipper.Test
             Assert.AreEqual("http://kissmanga.com/Manga/Onepunch-Man/Punch-001?id=369844", chapter.Url);
             var images = await service.FindImages(chapter, new Progress<int>(), source.Token);
             Assert.AreEqual(28, images.Count());
-            Assert.IsTrue(images.ToArray()[0].StartsWith("https://images1-focus-opensocial.googleusercontent.com/gadgets/proxy?container=focus&gadget=a&no_expand=1&resize_h=0&rewriteMime=image%2F*&url=http%3a%2f%2f2.bp.blogspot.com%2f-daAIY2sJQcE%2fV8rt280634I%2fAAAAAAAA404%2fLd1A6XZGrvcKioYmulO4MG8RcbPJf8zagCHM%2fs16000%2f0001-001.png&imgmax=30000"));
-            Assert.IsTrue(images.ToArray()[1].StartsWith("https://images1-focus-opensocial.googleusercontent.com/gadgets/proxy?container=focus&gadget=a&no_expand=1&resize_h=0&rewriteMime=image%2F*&url=http%3a%2f%2f2.bp.blogspot.com%2f-cx66pnwxYF4%2fV8rt3BUIFuI%2fAAAAAAAA408%2fC9nPR0AhT-oiTLiUzrKoo_K4JpGhv8OHACHM%2fs16000%2f0001-002.png&imgmax=30000"));
-            Assert.IsTrue(images.ToArray()[2].StartsWith("https://images1-focus-opensocial.googleusercontent.com/gadgets/proxy?container=focus&gadget=a&no_expand=1&resize_h=0&rewriteMime=image%2F*&url=http%3a%2f%2f2.bp.blogspot.com%2f-EfldQUNYKe8%2fV8rt3cmh-nI%2fAAAAAAAA41A%2f_O27IwHy_FkjCy8epn_zhccCy-6KRyCTwCHM%2fs16000%2f0001-003.png&imgmax=30000"));
+            Assert.IsTrue(images.ToArray()[0].StartsWith("http://2.bp.blogspot.com/-daAIY2sJQcE/V8rt280634I/AAAAAAAA404/Ld1A6XZGrvcKioYmulO4MG8RcbPJf8zagCHM/s16000/0001-001.png"));
+            Assert.IsTrue(images.ToArray()[1].StartsWith("http://2.bp.blogspot.com/-cx66pnwxYF4/V8rt3BUIFuI/AAAAAAAA408/C9nPR0AhT-oiTLiUzrKoo_K4JpGhv8OHACHM/s16000/0001-002.png"));
+            Assert.IsTrue(images.ToArray()[2].StartsWith("http://2.bp.blogspot.com/-EfldQUNYKe8/V8rt3cmh-nI/AAAAAAAA41A/_O27IwHy_FkjCy8epn_zhccCy-6KRyCTwCHM/s16000/0001-003.png"));
 
             string imageString = await downloader.DownloadStringAsync(images.ToArray()[0], source.Token);
             Assert.IsNotNull(imageString, "Cannot download image!");


### PR DESCRIPTION
Not a fix for #134, but a good boost for KissManga.
If we get the clearance cookies once - we should reuse it.