### PR TITLE
Feature/remove mangahere ad

### DIFF
--- a/MangaRipper.Plugin.MangaHere/MangaHere.cs
+++ b/MangaRipper.Plugin.MangaHere/MangaHere.cs
@@ -110,6 +110,13 @@ namespace MangaRipper.Plugin.MangaHere
 
             }
             while (nextButton != null && nextButton.Displayed);
+
+            // Remove the last page, because is always some commercial image, not from the comic
+            if (imgList.Count > 1)
+            {
+                imgList.RemoveAt(imgList.Count - 1);
+            }
+
             return await Task.FromResult(imgList);
         }
 

--- a/MangaRipper.Plugin.MangaHere/MangaHere.cs
+++ b/MangaRipper.Plugin.MangaHere/MangaHere.cs
@@ -77,8 +77,17 @@ namespace MangaRipper.Plugin.MangaHere
                 cancellationToken.ThrowIfCancellationRequested();
                 var currentDatapage = nextButton.GetAttribute("data-page");
                 nextButton.Click();
-                var src2 = img.GetAttribute("src");
-                imgList.Add(src2);
+                Wait.Until(driver =>
+                {
+                    var src2 = img.GetAttribute("src");
+                    if (!src2.EndsWith("loading.gif"))
+                    {
+                        imgList.Add(src2);
+                        return true;
+                    }
+                    return false;
+                });
+
                 progress.Report("Detecting: " + imgList.Count);
                 Wait.Until(d =>
                 {


### PR DESCRIPTION
The last image on MangaHere always is a advertisement. So I removed the last image.
I compared several downloads, but there seems not to be any other way to detect it.